### PR TITLE
Redirect to user profile on user avatar click

### DIFF
--- a/app/packs/src/components/chat/Message.jsx
+++ b/app/packs/src/components/chat/Message.jsx
@@ -22,6 +22,7 @@ const Message = (props) => {
       {!previousMessageSameUser && (
         <TalentProfilePicture
           src={mine ? user.profilePictureUrl : profilePictureUrl}
+          link={`talent/${props.username}`}
           height={48}
           className="mb-auto mt-2"
         />

--- a/app/packs/src/components/chat/MessageExchange.jsx
+++ b/app/packs/src/components/chat/MessageExchange.jsx
@@ -66,6 +66,7 @@ const MessageExchange = (props) => {
             </ThemedButton>
             <TalentProfilePicture
               src={props.profilePictureUrl}
+              link={`talent/${props.username}`}
               height={48}
               className="mr-2"
             />

--- a/app/packs/src/components/talent/TalentProfilePicture.jsx
+++ b/app/packs/src/components/talent/TalentProfilePicture.jsx
@@ -14,6 +14,7 @@ const TalentProfilePicture = ({
   straight,
   blur,
   border,
+  link,
 }) => {
   const [currentTheme, setCurrentTheme] = useState(document.body.className);
 
@@ -40,17 +41,26 @@ const TalentProfilePicture = ({
     setCurrentTheme(document.body.className);
   }, [document.body.className]);
 
-  return (
-    <img
-      className={`${roundPhoto}${grey}${blurPhoto}${borderPhoto} ${
-        className || ""
-      } image-fit`}
-      src={imgSrc()}
-      width={width || height}
-      height={height}
-      alt="Profile Picture"
-    />
+  const WithLink = ({ link, children }) => (link ?
+    <a href={link}>
+      {children}
+    </a>
+    : children
   );
+
+  return (
+    <WithLink link={link}>
+      <img
+        className={`${roundPhoto}${grey}${blurPhoto}${borderPhoto} ${
+          className || ""
+        } image-fit`}
+        src={imgSrc()}
+        width={width || height}
+        height={height}
+        alt="Profile Picture"
+      />
+    </WithLink>
+  )
 };
 
 TalentProfilePicture.defaultProps = {
@@ -62,6 +72,7 @@ TalentProfilePicture.defaultProps = {
   straight: null,
   blur: null,
   border: null,
+  link: null,
 };
 
 TalentProfilePicture.propTypes = {
@@ -73,6 +84,7 @@ TalentProfilePicture.propTypes = {
   straight: bool,
   blur: bool,
   border: bool,
+  link: string,
 };
 
 export default TalentProfilePicture;


### PR DESCRIPTION
Clicking on messages user avatar is now redirecting to the user profile page.

From now on passing the link prop to TalentProfilePicture will create a link to the desired path.

Tested both desktop and mobile.