### PR TITLE
Update message notifications to plural

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -44,8 +44,8 @@ class MessagesController < ApplicationController
     message = Message.create(sender: current_user, receiver: @receiver, text: message_params[:message])
     service = CreateNotification.new
     service.call(
-      title: "New message",
-      body: "You have a new message",
+      title: "New messages",
+      body: "You have new messages",
       user_id: @receiver.id,
       type: "Notifications::MessageReceived"
     )

--- a/lib/tasks/tmp/notifications.rake
+++ b/lib/tasks/tmp/notifications.rake
@@ -1,0 +1,8 @@
+namespace :notifications do
+  task update_to_plural: :environment do
+    Notification.where(type: "Notifications::MessageReceived").update_all(
+      title: "New messages",
+      body: "You have new messages"
+    )
+  end
+end


### PR DESCRIPTION
This PR updates message notifications to the plural.

## After merge
- [ ] Run `rails notifications:update_to_plural`