### PR TITLE
Change copy around invites area

### DIFF
--- a/app/packs/src/components/supporters/EditSupporter.jsx
+++ b/app/packs/src/components/supporters/EditSupporter.jsx
@@ -207,6 +207,53 @@ const EditSupporter = ({ id, username, email, profilePictureUrl, invites }) => {
 
   return (
     <div className="d-flex flex-column mx-auto align-items-center p-3 edit-profile-content">
+      <H5 className="w-100 text-left" text="Invites" bold />
+      <P2 className="w-100 text-left" text="Manage your invites" />
+      {invites.length == 0 ? (
+        <P2 className="w-100 text-left">
+          You current don't have any active invites.
+        </P2>
+      ) : (
+        ""
+      )}
+      {invites.map((invite) => (
+        <div className="w-100" key={`invite-${invite.id}`}>
+          <Divider className="my-4" />
+          <div className="d-flex flex-row flex-wrap w-100 justify-content-between align-items-end mt-2">
+            <P2 className="w-100 p2 text-left" bold>
+              {`${invite.talent_invite ? "Talent" : "Supporter"}`} invite
+            </P2>
+            <P2 className="w-100">
+              Invite your friends, earn 10 TAL per referral, and compete for the
+              big weekly prize of 1,000 TAL if you’re the first user to reach 15
+              invites.
+            </P2>
+            <div className="col-8 d-flex flex-column p-0 mt-2">
+              <P2 className="p2 text-left">
+                {invite.max_uses !== null
+                  ? `Uses: ${invite.uses}/${invite.max_uses}`
+                  : `Uses: ${invite.uses}`}
+              </P2>
+              <P2 className="p2 text-left">{`Code: ${invite.code}`}</P2>
+            </div>
+            <div>
+              <Button
+                onClick={() => addInviteToClipboard(invite)}
+                type="primary-default"
+                mode={theme.mode()}
+              >
+                Copy invite link{" "}
+                {copied[invite.id] ? (
+                  <Check color="currentColor" className="ml-2" />
+                ) : (
+                  ""
+                )}
+              </Button>
+            </div>
+          </div>
+        </div>
+      ))}
+      <Divider className="my-4" />
       <H5
         className="w-100 text-left"
         mode={theme.mode()}
@@ -335,48 +382,6 @@ const EditSupporter = ({ id, username, email, profilePictureUrl, invites }) => {
       >
         Change password
       </Button>
-      <Divider className="my-4" />
-      <H5 className="w-100 text-left" text="Invites" bold />
-      <P2 className="w-100 text-left" text="Manage your invites" />
-      {invites.length == 0 ? (
-        <P2 className="w-100 text-left">
-          You current don't have any active invites.
-        </P2>
-      ) : (
-        ""
-      )}
-      {invites.map((invite) => (
-        <div className="w-100" key={`invite-${invite.id}`}>
-          <Divider className="my-4" />
-          <div className="d-flex flex-row w-100 justify-content-between align-items-end mt-2">
-            <div className="col-8 d-flex flex-column p-0">
-              <P2 className="p2 text-left" bold>
-                {`${invite.talent_invite ? "Talent" : "Supporter"}`} invite
-              </P2>
-              <P2 className="p2 text-left">
-                {invite.max_uses !== null
-                  ? `Uses: ${invite.uses}/${invite.max_uses}`
-                  : `Uses: ${invite.uses}`}
-              </P2>
-              <P2 className="p2 text-left">{`Code: ${invite.code}`}</P2>
-            </div>
-            <div>
-              <Button
-                onClick={() => addInviteToClipboard(invite)}
-                type="primary-default"
-                mode={theme.mode()}
-              >
-                Copy invite link{" "}
-                {copied[invite.id] ? (
-                  <Check color="currentColor" className="ml-2" />
-                ) : (
-                  ""
-                )}
-              </Button>
-            </div>
-          </div>
-        </div>
-      ))}
       <Divider className="my-4" />
       <div className="d-flex flex-column w-100 my-3">
         <H5

--- a/app/packs/src/components/talent/Edit/Invites.jsx
+++ b/app/packs/src/components/talent/Edit/Invites.jsx
@@ -10,13 +10,26 @@ import {
 import Button from "src/components/design_system/button";
 import { ArrowLeft, ArrowRight, Check } from "src/components/icons";
 import LoadingButton from "src/components/button/LoadingButton";
-import Divider from "src/components/design_system/other/Divider";
 
-const InviteCard = ({ title, code, onClick, mode, copied, uses }) => {
+const TALENT_TEXT =
+  "Invite a talented friend to launch a token. They skip the traditional application process, receive $200 USD and you earn 100 TAL.";
+const SUPPORTER_TEXT =
+  "Every week the 3 users with the most referrals will win a total of 2,000 TAL (1st: 1200, 2nd: 500, 3rd: 300).";
+
+const InviteCard = ({
+  title,
+  code,
+  onClick,
+  mode,
+  copied,
+  explanation,
+  uses,
+}) => {
   return (
     <div className="w-100 invite-card p-4 d-flex flex-column my-2">
       <P1 bold>{title}</P1>
-      <P2>{uses}</P2>
+      <P2>{explanation}</P2>
+      <P2 className="mt-2">{uses}</P2>
       <div className="w-100 d-flex flex-row justify-content-between align-items-end mt-2">
         <div className="d-flex flex-column">
           <P3>Code</P3>
@@ -81,6 +94,7 @@ const Invites = (props) => {
         <InviteCard
           key={`invite-${invite.id}`}
           title={`${invite.talent_invite ? "Talent" : "Supporter"} invite`}
+          explanation={invite.talent_invite ? TALENT_TEXT : SUPPORTER_TEXT}
           code={invite.code}
           onClick={() => addInviteToClipboard(invite)}
           mode={mode}
@@ -88,7 +102,7 @@ const Invites = (props) => {
           uses={
             invite.max_uses !== null
               ? `Uses: ${invite.uses}/${invite.max_uses}`
-              : `Uses: ${invite.uses}`
+              : `Uses: ${invite.uses}/(unlimited)`
           }
         />
       ))}

--- a/app/packs/src/components/user_menu/index.jsx
+++ b/app/packs/src/components/user_menu/index.jsx
@@ -18,6 +18,14 @@ import { P2, P3 } from "src/components/design_system/typography";
 import { Sun, Moon } from "src/components/icons";
 
 const UserMenu = ({ user, toggleTheme, mode, onClickTransak, signOut }) => {
+  const onClickInvites = () => {
+    const url = user.isTalent
+      ? `/talent/${user.username}/edit_profile?tab=Invites`
+      : `/settings?tab=Invites`;
+
+    window.location.href = url;
+  };
+
   return (
     <Dropdown>
       <Dropdown.Toggle
@@ -58,18 +66,6 @@ const UserMenu = ({ user, toggleTheme, mode, onClickTransak, signOut }) => {
             <P3 bold text="My profile" className="text-black" />
           </Dropdown.Item>
         )}
-        <Dropdown.Divider className="user-menu-divider mx-2 my-0" />
-        <Dropdown.Item
-          key="tab-dropdown-change-investor-image"
-          className="text-black user-menu-dropdown-item"
-          href={
-            user.isTalent
-              ? `/talent/${user.username}/edit_profile?tab=Invites`
-              : `/settings?tab=Invites`
-          }
-        >
-          <P3 bold text="Invites" className="text-black" />
-        </Dropdown.Item>
         <Dropdown.Divider className="user-menu-divider mx-2 my-0" />
         <Dropdown.Item
           key="tab-dropdown-theme"
@@ -134,8 +130,15 @@ const UserMenu = ({ user, toggleTheme, mode, onClickTransak, signOut }) => {
           <P3 bold text="Sign out" className="text-black" />
         </Dropdown.Item>
         <Button
-          onClick={onClickTransak}
+          onClick={onClickInvites}
           type="primary-default"
+          className="w-100 mb-2"
+        >
+          <P3 bold text="Invites" className="text-white" />
+        </Button>
+        <Button
+          onClick={onClickTransak}
+          type="primary-outline"
           className="w-100"
         >
           <P3 bold text="Get funds" className="text-white" />

--- a/app/packs/stylesheets/custom/_button.scss
+++ b/app/packs/stylesheets/custom/_button.scss
@@ -33,7 +33,7 @@
 
 .primary-outline-button {
   color: $primary;
-  background-color: $white;
+  background-color: transparent;
   border: 1px solid $primary;
   line-height: 18px;
   font-size: 14px;
@@ -47,20 +47,20 @@
 
   &:disabled {
     color: $primary-outline-disabled !important;
-    background-color: $white !important;
+    background-color: transparent !important;
     border: 1px solid $primary-outline-disabled !important;
   }
 
   &:active {
     color: $primary;
-    background-color: $white;
+    background-color: transparent;
     border: 1px solid $primary;
   }
 }
 
 .dark-body .primary-outline-button {
   color: $primary;
-  background-color: $gray-800;
+  background-color: transparent;
 
   &:hover {
     color: $white;
@@ -70,13 +70,13 @@
 
   &:disabled {
     color: $primary-800 !important;
-    background-color: $gray-800 !important;
+    background-color: transparent !important;
     border: 1px solid $primary-800 !important;
   }
 
   &:active {
     color: $primary;
-    background-color: $gray-800;
+    background-color: transparent;
   }
 }
 
@@ -226,7 +226,7 @@
 
 .dark-body .danger-outline-button {
   color: $danger-tint-01;
-  background-color: $gray-800;
+  background-color: transparent;
   border: 1px solid $danger-tint-01;
 
   &:hover {
@@ -236,13 +236,13 @@
 
   &:disabled {
     color: $danger-shade-01 !important;
-    background-color: $gray-800 !important;
+    background-color: transparent !important;
     border: 1px solid $danger-shade-01 !important;
   }
 
   &:active {
     color: $danger-tint-01;
-    background-color: $gray-800;
+    background-color: transparent;
   }
 }
 
@@ -395,6 +395,7 @@
 
 .dark-body .positive-outline-button {
   color: $positive;
+  background-color: transparent;
   border: 1px solid $green-500;
 
   &:hover {
@@ -544,7 +545,7 @@
 
 .white-outline-button {
   color: $gray-800;
-  background-color: $white;
+  background-color: transparent;
   border: 1px solid $gray-800;
   line-height: 18px;
   font-size: 14px;
@@ -557,19 +558,19 @@
 
   &:disabled {
     color: $gray !important;
-    background-color: $white !important;
+    background-color: transparent !important;
     border: 1px solid $gray !important;
   }
 
   &:active {
     color: $gray-800;
-    background-color: $white;
+    background-color: transparent;
   }
 }
 
 .dark-body .white-outline-button {
   color: $white;
-  background-color: $gray-800;
+  background-color: transparent;
   border: 1px solid $white;
 
   &:hover {
@@ -579,13 +580,13 @@
 
   &:disabled {
     color: $gray-600 !important;
-    background-color: $gray-800 !important;
+    background-color: transparent !important;
     border: 1px solid $gray-600 !important;
   }
 
   &:active {
     color: $white;
-    background-color: $gray-800;
+    background-color: transparent;
   }
 }
 


### PR DESCRIPTION
## Summary

The invite section needs to be changed for a better copy.
The invite button on the user menu should be highlighted over the remaining options

### What changed?

Outline buttons and the invite option on the user menu

### Why it changed?

In order to help push our growth we need to give more visibility to invites 

### How it changed?

Outline buttons now have transparent background instead of a fixed color.
The invite option is now a primary button on the user menu.
Added copy to the invite cards on the settings page for both supporters and talent.

## Notion link

https://talentprotocol.notion.site/Invite-Race-87498c5b6d4e461896809131c64756c2

## How to test?

Check the invites link on the user menu dropdown for a talent and for a supporter

## Notes

N/A