### PR TITLE
Don't allow user params from being part of the json response

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,6 +95,11 @@ class User < ApplicationRecord
     new_email && new_email.length > 0 && new_email.match?(/^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/)
   end
 
+  def as_json(options = {})
+    options[:except] ||= [:remember_token, :encrypted_password, :confirmation_token, :last_sign_in_at, :nounce, :email_confirmation_token]
+    super(options)
+  end
+
   private
 
   def role_is_valid


### PR DESCRIPTION
## Summary

Some users fields were being returned to the frontend in response to updates but they should be kept private.

### What changed?

as_json

### Why it changed?

to ignore private fields

### How it changed?

overridden the as_json method

## Notion link

https://www.notion.so/talentprotocol/Whitejar-security-findings-e9b7edbbc4964e12832ed6e7a9350b17

## How to test?

make a request that updates the user through /api/v1/users

## Notes
