### PR TITLE
Fix supporters list view

### DIFF
--- a/app/packs/src/components/chat/Chat.jsx
+++ b/app/packs/src/components/chat/Chat.jsx
@@ -175,8 +175,13 @@ const Chat = ({ users, user }) => {
   }, [activeUserId]);
 
   const messagingDisabled = () => {
-    const activeUser = users.find(user => user.id === activeUserId)
+    const activeUser = users.find(user => user.id == activeUserId)
     return user.messagingDisabled || (activeUser && activeUser.messagingDisabled)
+  }
+
+  const activeUserWithTalent = () => {
+    const activeUser = users.find(user => user.id == activeUserId)
+    return (activeUser && activeUser.withTalent)
   }
 
   return (
@@ -209,6 +214,7 @@ const Chat = ({ users, user }) => {
                 user={user}
                 profilePictureUrl={messengerProfilePicture}
                 username={messengerUsername}
+                messengerWithTalent={activeUserWithTalent()}
                 mode={theme.mode()}
               />
             </section>

--- a/app/packs/src/components/chat/Message.jsx
+++ b/app/packs/src/components/chat/Message.jsx
@@ -11,9 +11,11 @@ const Message = (props) => {
     mine,
     profilePictureUrl,
     username,
+    profileLink,
     previousMessageSameUser,
     user,
   } = props;
+
   const sentDate = dayjs(message.created_at).format("MMM D, YYYY, h:m A");
 
   return (
@@ -21,7 +23,7 @@ const Message = (props) => {
       {!previousMessageSameUser && (
         <TalentProfilePicture
           src={mine ? user.profilePictureUrl : profilePictureUrl}
-          link={`talent/${props.username}`}
+          link={profileLink}
           height={48}
           className="mb-auto mt-3"
         />

--- a/app/packs/src/components/chat/MessageExchange.jsx
+++ b/app/packs/src/components/chat/MessageExchange.jsx
@@ -57,6 +57,26 @@ const MessageExchange = (props) => {
     }
   };
 
+  const mine = (message) => message && message.sender_id === props.user.id
+
+  const link = (message) => {
+    const {
+      user,
+      username,
+      messengerWithTalent
+    } = props;
+
+    if(mine(message)) {
+      if(user.withTalent) {
+        return `talent/${user.username}`
+      }
+    } else {
+      if(messengerWithTalent) {
+        return `talent/${username}`
+      }
+    }
+  };
+
   return (
     <div className="h-100 d-flex flex-column">
       {props.smallScreen && (
@@ -72,7 +92,7 @@ const MessageExchange = (props) => {
             </ThemedButton>
             <TalentProfilePicture
               src={props.profilePictureUrl}
-              link={`talent/${props.username}`}
+              link={link()}
               height={48}
               className="mr-2"
             />
@@ -96,7 +116,8 @@ const MessageExchange = (props) => {
             key={`message_${message.id}`}
             message={message}
             previousMessageSameUser={isPreviousMessageFromSameSender(index)}
-            mine={message.sender_id === props.user.id}
+            mine={mine(message)}
+            profileLink={link(message)}
             profilePictureUrl={props.profilePictureUrl}
             username={props.username}
             user={props.user}

--- a/app/packs/src/components/portfolio/components/Supporters.jsx
+++ b/app/packs/src/components/portfolio/components/Supporters.jsx
@@ -10,6 +10,7 @@ import { get } from "src/utils/requests";
 import {
   H4,
   H5,
+  P1,
   P2,
   P3,
   Caption,
@@ -520,7 +521,7 @@ const Supporters = ({
             ticker={ticker}
             userId={supporterInfo[activeSupporter.id]?.id}
             currentUserId={currentUserId}
-            messagingDisabled={supporterInfo[activeSupporter.id]?.messagingDisabled || props.messagingDisabled}
+            messagingDisabled={supporterInfo[activeSupporter.id]?.messagingDisabled || messagingDisabled}
           />
         )}
         <MobileSupportersDropdown
@@ -686,7 +687,7 @@ const Supporters = ({
                     !supporterInfo[supporter.id]?.id ||
                     supporterInfo[supporter.id]?.id == currentUserId ||
                     supporterInfo[supporter.id]?.messagingDisabled ||
-                    props.messagingDisabled
+                    messagingDisabled
                   }
                   href={`/messages?user=${supporterInfo[supporter.id]?.id}`}
                 />

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -6,6 +6,7 @@
         id: user.id,
         username: user.username,
         ticker: user.talent&.token&.ticker,
+        withTalent: user.talent.present?,
         last_message: current_user.last_message_with(user)&.text,
         last_message_date: current_user.last_message_with(user)&.created_at,
         profilePictureUrl: user.talent&.profile_picture_url || user.investor&.profile_picture_url,
@@ -17,7 +18,8 @@
       id: current_user.id,
       username: current_user.username,
       profilePictureUrl: current_user.talent&.profile_picture_url || current_user.investor&.profile_picture_url,
-      messagingDisabled: current_user.messaging_disabled
+      messagingDisabled: current_user.messaging_disabled,
+      withTalent: current_user.talent.present?
     }
   }, prerender: false, html_options: { class: "h-100" })
 %>


### PR DESCRIPTION
## Summary

### What changed?

Supporters list view should now show up correctly.
Message profile picture redirects to profile page only if the user has a talent.

### Why it changed?

It was not displaying.
It was redirecting the user to investors not existent profile pages.

### How it changed?

Accessing the `messagingDisabled` variable correctly.
Add logic to verify if the chat user has a talent before displaying the link.

## Notion link

<!--- Link to the Notion task. -->

## How to test?

Assert that the supporters list view renders correctly in the Portfolio tab.
Assert investors profile pictures are not clickable.

## Notes

<!--- Notes you might consider worth adding. -->