### PR TITLE
Fix invites lookup on upgrade to talent and destroy user

### DIFF
--- a/app/services/destroy_user.rb
+++ b/app/services/destroy_user.rb
@@ -8,9 +8,10 @@ class DestroyUser
   def call
     user = User.find(@user_id)
     ActiveRecord::Base.transaction do
-      if user.invite.present?
-        user.invite.update!(user_id: 1)
+      if user.invites.count > 0
+        user.invites.update_all(user_id: 1)
       end
+
       user.feed.feed_posts.destroy_all
       user.feed.destroy!
       user.investor.destroy!

--- a/app/services/supporter/upgrade_to_talent.rb
+++ b/app/services/supporter/upgrade_to_talent.rb
@@ -19,8 +19,8 @@ class Supporter::UpgradeToTalent
   private
 
   def create_invite(user)
-    if user.invite
-      user.invite.update!(max_uses: nil)
+    if user.invites.count > 0
+      user.invites.first.update!(max_uses: nil)
     else
       service = CreateInvite.new(user_id: user.id)
       service.call

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,12 @@ require "sidekiq/web"
 require "sidekiq-scheduler/web"
 
 Rails.application.routes.draw do
+  # Admin area
+  constraints Clearance::Constraints::SignedIn.new { |user| user.admin? } do
+    mount Sidekiq::Web => "/sidekiq"
+  end
+  # end Admin
+
   # Business - require log-in
   constraints Clearance::Constraints::SignedIn.new do
     root to: "talent#index", as: :user_root


### PR DESCRIPTION
## Summary

Due to a recent change on invites the destroy user method was failing

### What changed?

We now take into account that there can be multiple invites

### Why it changed?

Because a user can now have multiple invites

### How it changed?

We now lookup the array of invites

## Notion link

N/A

## How to test?

Attempt to destroy a user

## Notes

N/A