### PR TITLE
Quick wins on Discovery page

### DIFF
--- a/app/controllers/discovery_controller.rb
+++ b/app/controllers/discovery_controller.rb
@@ -17,7 +17,6 @@ class DiscoveryController < ApplicationController
           .where(id: ids)
           .select("setseed(0.#{Date.today.jd}), talent.*")
           .order("random()")
-          .limit(4)
       }
     end
 

--- a/app/packs/src/components/design_system/cards/MarketingCard.jsx
+++ b/app/packs/src/components/design_system/cards/MarketingCard.jsx
@@ -12,19 +12,21 @@ import cx from "classnames";
 const MarketingCard = ({ link, title, imgUrl, description, user, date }) => {
   return (
     <a
-      className="marketing-card d-flex flex-column"
+      className="marketing-card d-flex flex-column justify-content-between"
       href={link}
       target="_blank"
     >
-      <img
-        className={cx("image-fit")}
-        src={imgUrl}
-        width="100%"
-        height={184}
-        alt="Marketing Picture"
-      />
-      <P1 className="text-black mt-3" bold text={title} />
-      <P2 className="text-primary-03" text={description} />
+      <div className="d-flex flex-column">
+        <img
+          className={cx("image-fit")}
+          src={imgUrl}
+          width="100%"
+          height={184}
+          alt="Marketing Picture"
+        />
+        <P1 className="text-black mt-3" bold text={title} />
+        <P2 className="text-primary-03" text={description} />
+      </div>
       <div className="d-flex flex-row align-items-center mt-2">
         <TalentProfilePicture src={user.profilePictureUrl} height={32} />
         <div className="d-flex flex-column ml-3">

--- a/app/packs/src/components/design_system/cards/NewTalentCard.jsx
+++ b/app/packs/src/components/design_system/cards/NewTalentCard.jsx
@@ -72,7 +72,7 @@ const NewTalentCard = ({
               </div>
             </div>
             <button
-              className="button-link ml-2 z-index-1"
+              className="button-link ml-2"
               onClick={(e) => updateFollowing(e)}
             >
               <Star pathClassName={isFollowing ? "star" : "star-outline"} />

--- a/app/packs/src/components/discovery/discovery_marketing_articles.jsx
+++ b/app/packs/src/components/discovery/discovery_marketing_articles.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { useWindowDimensionsHook } from "src/utils/window";
+import { P1 } from "src/components/design_system/typography";
+import MarketingCard from "src/components/design_system/cards/MarketingCard";
+
+import cx from "classnames";
+
+const DiscoveryMarketingArticles = ({ marketingArticles }) => {
+  const { mobile } = useWindowDimensionsHook();
+
+  return (
+    <>
+      <P1
+        className={cx("text-black", mobile && "ml-4")}
+        bold
+        text="More from Talent Protocol"
+      />
+      <div
+        className={cx(
+          "d-flex flex-wrap mb-4",
+          mobile ? "justify-content-center" : "justify-content-between"
+        )}
+      >
+        {marketingArticles.map((article) => (
+          <div key={article.id} className="mt-3">
+            <MarketingCard
+              link={article.link}
+              title={article.title}
+              imgUrl={article.imgUrl}
+              description={article.description}
+              user={article.user}
+              date={article.date}
+            />
+          </div>
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default DiscoveryMarketingArticles;

--- a/app/packs/src/components/discovery/discovery_rows.jsx
+++ b/app/packs/src/components/discovery/discovery_rows.jsx
@@ -1,0 +1,144 @@
+import React, { useState, useCallback } from "react";
+import { useWindowDimensionsHook } from "src/utils/window";
+import { P1 } from "src/components/design_system/typography";
+import {
+  faChevronLeft,
+  faChevronRight,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Caret } from "src/components/icons";
+import NewTalentCard from "src/components/design_system/cards/NewTalentCard";
+import Button from "src/components/design_system/button";
+
+import cx from "classnames";
+
+const DiscoveryRows = ({ discoveryRows, updateFollow }) => {
+  const [start, setStart] = useState(
+    discoveryRows
+      .map((row) => row.title)
+      .reduce((acc, curr) => ((acc[curr] = 0), acc), {})
+  );
+  const { mobile, width } = useWindowDimensionsHook();
+
+  const itemsPerRow = useCallback(
+    (talents) => {
+      if (width < 992) {
+        return talents.length;
+      }
+
+      const card = 272;
+      const actualWidth = width > 1240 ? 1240 : width;
+
+      const numberOfCards = actualWidth / card;
+
+      return Math.floor(numberOfCards);
+    },
+    [width]
+  );
+
+  const end = (title, talents) =>
+    talents.length > itemsPerRow(talents)
+      ? start[title] + itemsPerRow(talents)
+      : talents.length;
+
+  const sliceInDisplay = (title, talents) =>
+    talents.slice(start[title], end(title, talents));
+
+  const slideLeft = (title, talents) => {
+    if (start[title] - itemsPerRow(talents) < 0) {
+      setStart((prev) => ({ ...prev, [title]: 0 }));
+    } else {
+      setStart((prev) => ({
+        ...prev,
+        [title]: prev[title] - itemsPerRow(talents),
+      }));
+    }
+  };
+  const slideRight = (title, talents) => {
+    if (start[title] + itemsPerRow(talents) >= talents.length) {
+      setStart((prev) => ({ ...prev, [title]: talents.length - 1 }));
+    } else {
+      setStart((prev) => ({
+        ...prev,
+        [title]: prev[title] + itemsPerRow(talents),
+      }));
+    }
+  };
+  const disableLeft = (title) => start[title] === 0;
+  const disableRight = (title, talents) =>
+    start[title] + itemsPerRow(talents) >= talents.length;
+
+  return (
+    <>
+      {discoveryRows.map((row) => (
+        <div key={row.title}>
+          {row.talents.length > 0 ? (
+            <div className="mt-6">
+              <div className="d-flex justify-content-between">
+                <P1
+                  bold
+                  text={row.title}
+                  className={cx("text-black", mobile && "pl-4")}
+                />
+                {row.talents.length > itemsPerRow(row.talents) && (
+                  <div className="d-flex flex-row">
+                    <Button
+                      onClick={() => slideLeft(row.title, row.talents)}
+                      disabled={disableLeft(row.title)}
+                      type="white-ghost"
+                      className="mr-2"
+                    >
+                      <Caret
+                        size={16}
+                        color="currentColor"
+                        className="rotate-90"
+                      />
+                    </Button>
+                    <Button
+                      onClick={() => slideRight(row.title, row.talents)}
+                      disabled={disableRight(row.title, row.talents)}
+                      type="white-ghost"
+                    >
+                      <Caret
+                        size={16}
+                        color="currentColor"
+                        className="rotate-270"
+                      />
+                    </Button>
+                  </div>
+                )}
+              </div>
+              <div
+                className={cx(
+                  "w-100 d-flex horizontal-scroll hide-scrollbar talents-cards-container justify-start",
+                  mobile && "pl-4"
+                )}
+              >
+                {sliceInDisplay(row.title, row.talents).map((talent) => (
+                  <div key={talent.id} className="pt-3 pr-4">
+                    <NewTalentCard
+                      name={talent.name}
+                      ticker={talent.ticker}
+                      occupation={talent.occupation}
+                      profilePictureUrl={talent.profilePictureUrl}
+                      headline={talent.headline}
+                      isFollowing={talent.isFollowing}
+                      updateFollow={() => updateFollow(talent)}
+                      talentLink={`/talent/${talent.username}`}
+                      marketCap={talent.marketCap}
+                      supporterCount={talent.supporterCount}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <></>
+          )}
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default DiscoveryRows;

--- a/app/packs/src/components/discovery/index.jsx
+++ b/app/packs/src/components/discovery/index.jsx
@@ -1,7 +1,7 @@
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useState, useCallback } from "react";
 
-import { get, post, destroy } from "src/utils/requests";
-import { useWindowDimensionsHook } from "../../utils/window";
+import { post, destroy } from "src/utils/requests";
+import { useWindowDimensionsHook } from "src/utils/window";
 import { ethers } from "ethers";
 import { parseAndCommify } from "src/onchain/utils";
 import {
@@ -11,10 +11,11 @@ import {
   client,
 } from "src/utils/thegraph";
 
-import { H2, P1 } from "src/components/design_system/typography";
+import { H2 } from "src/components/design_system/typography";
 import HighlightsCard from "src/components/design_system/highlights_card";
-import NewTalentCard from "src/components/design_system/cards/NewTalentCard";
-import MarketingCard from "src/components/design_system/cards/MarketingCard";
+
+import DiscoveryRows from "./discovery_rows";
+import DiscoveryMarketingArticles from "./discovery_marketing_articles";
 
 import cx from "classnames";
 
@@ -141,66 +142,15 @@ const Discovery = ({ discoveryRows, marketingArticles }) => {
           link="/talent?status=Launching+soon"
         />
       </div>
-      <div>
-        {localDiscoveryRows.map((row) => (
-          <div key={row.title} className="mt-6">
-            <P1
-              bold
-              text={row.title}
-              className={cx("text-black", mobile && "ml-4")}
-            />
-            <div
-              className={cx(
-                "w-100 d-flex flex-wrap",
-                mobile ? "justify-content-center" : "justify-content-between"
-              )}
-            >
-              {row.talents.map((talent) => (
-                <div key={talent.id} className="mt-3">
-                  <NewTalentCard
-                    name={talent.name}
-                    ticker={talent.ticker}
-                    occupation={talent.occupation}
-                    profilePictureUrl={talent.profilePictureUrl}
-                    headline={talent.headline}
-                    isFollowing={talent.isFollowing}
-                    updateFollow={() => updateFollow(talent)}
-                    talentLink={`/talent/${talent.username}`}
-                    marketCap={talent.marketCap}
-                    supporterCount={talent.supporterCount}
-                  />
-                </div>
-              ))}
-            </div>
-          </div>
-        ))}
-      </div>
-      <div className="mt-6 mb-4">
-        <P1
-          className={cx("text-black", mobile && "ml-4")}
-          bold
-          text="More from Talent Protocol"
-        />
-        <div
-          className={cx(
-            "d-flex flex-wrap mb-4",
-            mobile ? "justify-content-center" : "justify-content-between"
-          )}
-        >
-          {marketingArticles.map((article) => (
-            <div key={article.id} className="mt-3">
-              <MarketingCard
-                link={article.link}
-                title={article.title}
-                imgUrl={article.imgUrl}
-                description={article.description}
-                user={article.user}
-                date={article.date}
-              />
-            </div>
-          ))}
+      <DiscoveryRows
+        discoveryRows={localDiscoveryRows}
+        updateFollow={updateFollow}
+      />
+      {marketingArticles.length > 0 && (
+        <div className="mt-6 mb-4">
+          <DiscoveryMarketingArticles marketingArticles={marketingArticles} />
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/app/packs/src/components/portfolio/components/Supporters.jsx
+++ b/app/packs/src/components/portfolio/components/Supporters.jsx
@@ -31,7 +31,7 @@ const MobileSupporterAction = ({
   ticker,
   userId,
   currentUserId,
-  messagingDisabled
+  messagingDisabled,
 }) => {
   return (
     <Modal
@@ -114,7 +114,7 @@ const MobileSupportersDropdown = ({
         >
           Amount{" "}
           {selectedOption == "Amount" && (
-            <OrderBy className={order == "asc" ? "" : "rotate-svg"} />
+            <OrderBy className={order == "asc" ? "" : "rotate-180"} />
           )}
         </Button>
         <Button
@@ -127,7 +127,7 @@ const MobileSupportersDropdown = ({
         >
           Unclaimed Rewards{" "}
           {selectedOption == "Rewards" && (
-            <OrderBy className={order == "asc" ? "" : "rotate-svg"} />
+            <OrderBy className={order == "asc" ? "" : "rotate-180"} />
           )}
         </Button>
         <Button
@@ -140,7 +140,7 @@ const MobileSupportersDropdown = ({
         >
           Alphabetical Order
           {selectedOption == "Alphabetical Order" && (
-            <OrderBy className={order == "asc" ? "" : "rotate-svg"} />
+            <OrderBy className={order == "asc" ? "" : "rotate-180"} />
           )}
         </Button>
       </Modal.Body>
@@ -268,7 +268,7 @@ const Supporters = ({
   chainAPI,
   mobile,
   currentUserId,
-  messagingDisabled
+  messagingDisabled,
 }) => {
   const { loading, error, data } = useQuery(GET_TALENT_PORTFOLIO_FOR_ID, {
     variables: { id: tokenAddress?.toLowerCase() },
@@ -520,7 +520,10 @@ const Supporters = ({
             ticker={ticker}
             userId={supporterInfo[activeSupporter.id]?.id}
             currentUserId={currentUserId}
-            messagingDisabled={supporterInfo[activeSupporter.id]?.messagingDisabled || props.messagingDisabled}
+            messagingDisabled={
+              supporterInfo[activeSupporter.id]?.messagingDisabled ||
+              props.messagingDisabled
+            }
           />
         )}
         <MobileSupportersDropdown

--- a/app/packs/src/components/portfolio/components/Supporting.jsx
+++ b/app/packs/src/components/portfolio/components/Supporting.jsx
@@ -49,7 +49,7 @@ const MobileSupportingDropdown = ({
         >
           Amount{" "}
           {selectedOption == "Amount" && (
-            <OrderBy className={order == "asc" ? "" : "rotate-svg"} />
+            <OrderBy className={order == "asc" ? "" : "rotate-180"} />
           )}
         </Button>
         <Button
@@ -62,7 +62,7 @@ const MobileSupportingDropdown = ({
         >
           Unclaimed Rewards{" "}
           {selectedOption == "Rewards" && (
-            <OrderBy className={order == "asc" ? "" : "rotate-svg"} />
+            <OrderBy className={order == "asc" ? "" : "rotate-180"} />
           )}
         </Button>
         <Button
@@ -75,7 +75,7 @@ const MobileSupportingDropdown = ({
         >
           Alphabetical Order
           {selectedOption == "Alphabetical Order" && (
-            <OrderBy className={order == "asc" ? "" : "rotate-svg"} />
+            <OrderBy className={order == "asc" ? "" : "rotate-180"} />
           )}
         </Button>
       </Modal.Body>

--- a/app/packs/src/components/talent/Show/Supporters.jsx
+++ b/app/packs/src/components/talent/Show/Supporters.jsx
@@ -48,7 +48,7 @@ const MobileSupportersDropdown = ({
         >
           Amount{" "}
           {selectedOption == "Amount" && (
-            <OrderBy className={order == "asc" ? "" : "rotate-svg"} />
+            <OrderBy className={order == "asc" ? "" : "rotate-180"} />
           )}
         </Button>
         <Button
@@ -61,7 +61,7 @@ const MobileSupportersDropdown = ({
         >
           Alphabetical Order
           {selectedOption == "Alphabetical Order" && (
-            <OrderBy className={order == "asc" ? "" : "rotate-svg"} />
+            <OrderBy className={order == "asc" ? "" : "rotate-180"} />
           )}
         </Button>
       </Modal.Body>

--- a/app/packs/src/components/talent/TalentFilters.jsx
+++ b/app/packs/src/components/talent/TalentFilters.jsx
@@ -20,7 +20,7 @@ const TalentFilters = ({ status, setStatus, filter }) => {
     <Dropdown>
       <Dropdown.Toggle
         className="talent-button white-subtle-button normal-size-button no-caret d-flex justify-content-between align-items-center"
-        id="user-dropdown"
+        id="talent-filters-dropdown"
         bsPrefix=""
         as="div"
         style={{ height: 34, width: 150 }}

--- a/app/packs/src/components/talent/TalentTableListMode.jsx
+++ b/app/packs/src/components/talent/TalentTableListMode.jsx
@@ -46,7 +46,7 @@ const MobileTalentTableDropdown = ({
             text="Supporters"
           />
           {selectedOption == "Supporters" && (
-            <OrderBy className={order == "asc" ? "" : "rotate-svg"} />
+            <OrderBy className={order == "asc" ? "" : "rotate-180"} />
           )}
         </Button>
         <Button
@@ -61,7 +61,7 @@ const MobileTalentTableDropdown = ({
             text="Occupation"
           />
           {selectedOption == "Occupation" && (
-            <OrderBy className={order == "asc" ? "" : "rotate-svg"} />
+            <OrderBy className={order == "asc" ? "" : "rotate-180"} />
           )}
         </Button>
         <Button
@@ -76,7 +76,7 @@ const MobileTalentTableDropdown = ({
             text="Market Cap"
           />
           {selectedOption == "Circulating Supply" && (
-            <OrderBy className={order == "asc" ? "" : "rotate-svg"} />
+            <OrderBy className={order == "asc" ? "" : "rotate-180"} />
           )}
         </Button>
         <Button
@@ -91,7 +91,7 @@ const MobileTalentTableDropdown = ({
             text="Alphabetical Order"
           />
           {selectedOption == "Alphabetical Order" && (
-            <OrderBy className={order == "asc" ? "" : "rotate-svg"} />
+            <OrderBy className={order == "asc" ? "" : "rotate-180"} />
           )}
         </Button>
       </Modal.Body>

--- a/app/packs/src/components/user_menu/index.jsx
+++ b/app/packs/src/components/user_menu/index.jsx
@@ -1,10 +1,7 @@
 import React from "react";
 import Dropdown from "react-bootstrap/Dropdown";
 import TalentProfilePicture from "../talent/TalentProfilePicture";
-import {
-  faAngleDown,
-  faExternalLinkAlt,
-} from "@fortawesome/free-solid-svg-icons";
+import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   SUPPORTER_GUIDE,

--- a/app/packs/stylesheets/custom/_cards.scss
+++ b/app/packs/stylesheets/custom/_cards.scss
@@ -275,6 +275,7 @@
 .highlights-card-title {
   height: 74px;
   width: 100%;
+  border-radius: 4px;
 }
 
 .dark-body .highlights-card-title {
@@ -323,6 +324,7 @@
   box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.04);
   width: 272px;
   height: 356px;
+  border-radius: 4px;
 
   &:hover {
     box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.1);
@@ -349,6 +351,7 @@
   padding-bottom: 16px;
   padding-left: 16px;
   padding-right: 16px;
+  border-radius: 4px 4px 0px 0px;
 }
 
 .dark-body .talent-card-title {
@@ -358,6 +361,7 @@
 .talent-card-body {
   height: 75px;
   padding: 16px;
+  border-radius: 0px 0px 4px 4px;
 }
 
 .dark-body .talent-card-body {
@@ -414,6 +418,7 @@
 
 .marketing-card {
   width: 374px;
+  height: 387px;
   padding: 16px;
   border-radius: 4px;
   text-decoration: none !important;

--- a/app/packs/stylesheets/custom/_shared.scss
+++ b/app/packs/stylesheets/custom/_shared.scss
@@ -276,8 +276,16 @@
   border: none !important;
 }
 
-.rotate-svg {
+.rotate-90 {
+  transform: rotate(90deg);
+}
+
+.rotate-180 {
   transform: rotate(180deg);
+}
+
+.rotate-270 {
+  transform: rotate(270deg);
 }
 
 .dark-body .bg-light {


### PR DESCRIPTION
## Summary
Some quick wins on Discovery page

### What changed?
Hide empty sections
Left align cards
Reduce number of cards on smaller screens
Show more than 4 talents per row with option to rotate between them
Add fixed height to marketing cards
Add border radius to all cards

### Why it changed?
Looks and feels better
### How it changed?

## Notion link
https://www.notion.so/talentprotocol/Discover-Page-cb43b707fd36424ea91b1d20844bd82e

## How to test?
Open Discovery page and check what changed
