### PR TITLE
Fix confirmation email

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,6 +32,8 @@ class UsersController < ApplicationController
         theme_preference: user_params[:theme_preference]
       )
 
+      UserMailer.with(user: @result[:user]).send_sign_up_email.deliver_later
+
       if @result[:success]
         render json: @result[:user], status: :created
       else

--- a/app/services/create_user.rb
+++ b/app/services/create_user.rb
@@ -29,8 +29,6 @@ class CreateUser
 
       create_invite(user)
 
-      UserMailer.with(user: user).send_sign_up_email.deliver_later
-
       @result[:user] = user
       @result[:success] = true
       @result


### PR DESCRIPTION
## Summary

We have a bunch of errors due to attempting to queue up the user mailer worker without the user being committed to the database

### What changed?

We now send the email after the transaction block is finished

### Why it changed?

Sometimes when the worker ran it couldn't find the user yet and so it threw an exception

### How it changed?

Removing the usermailer call from inside the transaction and moving it to the controller.

## Notion link

N/A

## How to test?

Create multiple new users to confirm that the exception no longer happens

## Notes

N/A