### PR TITLE
Only send email on success

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,9 +32,9 @@ class UsersController < ApplicationController
         theme_preference: user_params[:theme_preference]
       )
 
-      UserMailer.with(user: @result[:user]).send_sign_up_email.deliver_later
-
       if @result[:success]
+        UserMailer.with(user: @result[:user]).send_sign_up_email.deliver_later
+
         render json: @result[:user], status: :created
       else
         render json: @result, status: :conflict


### PR DESCRIPTION
## Summary

We should only send the email on a successful user creation

### What changed?

we now check for the success message before attempting to send the sign up email

### Why it changed?

because otherwise we could be sending email at the wrong time

### How it changed?

check for success before sending the email

## Notion link

N/A

## How to test?

Create a new user

## Notes

N/A