### PR TITLE
Only show active talents in Discovery page

### DIFF
--- a/app/controllers/discovery_controller.rb
+++ b/app/controllers/discovery_controller.rb
@@ -5,6 +5,7 @@ class DiscoveryController < ApplicationController
     DiscoveryRow.find_each do |row|
       ids = Talent
         .base
+        .active
         .joins(:tags)
         .where(tags: {id: row.tags.pluck(:id)})
         .distinct

--- a/app/packs/src/components/talent/TalentTableListMode.jsx
+++ b/app/packs/src/components/talent/TalentTableListMode.jsx
@@ -249,7 +249,7 @@ const TalentTableListMode = ({
             className="cursor-pointer"
           />
         </Table.Th>
-        <Table.Th>
+        <Table.Th className="col-2">
           <Caption
             onClick={() => onOptionClick("Market Cap")}
             bold
@@ -318,10 +318,10 @@ const TalentTableListMode = ({
               />
             </Table.Td>
             <Table.Td
-              className={
-                (cx("pr-3"),
-                talent.token.contractId ? "" : "d-flex justify-content-center")
-              }
+              className={cx(
+                "pr-3",
+                talent.token.contractId ? "" : "d-flex justify-content-center"
+              )}
               onClick={() =>
                 (window.location.href = `/talent/${talent.user.username}`)
               }

--- a/app/packs/stylesheets/custom/_cards.scss
+++ b/app/packs/stylesheets/custom/_cards.scss
@@ -313,12 +313,6 @@
   color: $primary-400;
 }
 
-.talents-cards-container {
-  :nth-child(4n) {
-    padding-right: 0 !important;
-  }
-}
-
 .talent-card {
   background-color: $white;
   box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.04);
@@ -432,5 +426,29 @@
   &:hover {
     box-shadow: none;
     background-color: $gray-900;
+  }
+}
+
+@media (min-width: 1240px) {
+  .talents-cards-container {
+    :nth-child(4n) {
+      padding-right: 0 !important;
+    }
+  }
+}
+
+@media (max-width: 1239px) {
+  .talents-cards-container {
+    :nth-child(4n) {
+      padding-right: 24px !important;
+    }
+  }
+}
+
+@media (max-width: 992px) {
+  .talents-cards-container {
+    :nth-child(4n) {
+      padding-right: 0px !important;
+    }
   }
 }

--- a/app/packs/stylesheets/custom/_shared.scss
+++ b/app/packs/stylesheets/custom/_shared.scss
@@ -212,7 +212,6 @@
 
 .horizontal-scroll {
   overflow: auto;
-  white-space: nowrap;
 }
 
 .icon-bar {


### PR DESCRIPTION
## Summary
Only show active talents in Discovery page
Fix headline of talent cards in Discovery page
Show table with occupation even if it's too big