### PR TITLE
Create public profile

### DIFF
--- a/app/blueprints/career_goal_blueprint.rb
+++ b/app/blueprints/career_goal_blueprint.rb
@@ -1,0 +1,10 @@
+class CareerGoalBlueprint < Blueprinter::Base
+  fields :id, :description
+
+  view :normal do
+    fields :target_date, :bio, :pitch, :challenges
+    field :goals do |career_goal, _options|
+      career_goal.goals.order(:due_date)
+    end
+  end
+end

--- a/app/blueprints/milestone_blueprint.rb
+++ b/app/blueprints/milestone_blueprint.rb
@@ -1,0 +1,7 @@
+class MilestoneBlueprint < Blueprinter::Base
+  fields :id, :title, :description
+
+  view :normal do
+    fields :start_date, :end_date, :link, :institution
+  end
+end

--- a/app/blueprints/perk_blueprint.rb
+++ b/app/blueprints/perk_blueprint.rb
@@ -1,0 +1,3 @@
+class PerkBlueprint < Blueprinter::Base
+  fields :id, :price, :title
+end

--- a/app/blueprints/tag_blueprint.rb
+++ b/app/blueprints/tag_blueprint.rb
@@ -1,0 +1,3 @@
+class TagBlueprint < Blueprinter::Base
+  fields :id, :description
+end

--- a/app/blueprints/talent_blueprint.rb
+++ b/app/blueprints/talent_blueprint.rb
@@ -3,11 +3,23 @@ class TalentBlueprint < Blueprinter::Base
 
   view :normal do
     fields :occupation, :headline, :user_id
-    association :token, blueprint: TokenBlueprint
+    association :token, blueprint: TokenBlueprint, view: :normal
     association :user, blueprint: UserBlueprint, view: :normal
 
     field :is_following do |talent, options|
-      options[:current_user].following.where(user_id: talent.user_id).exists?
+      options[:current_user]&.following&.where(user_id: talent.user_id)&.exists?
     end
+  end
+
+  view :extended do
+    include_view :normal
+    fields :banner_url, :profile
+    association :user, blueprint: UserBlueprint, view: :extended
+    association :perks, blueprint: PerkBlueprint
+    association :tags, blueprint: TagBlueprint do |talent, options|
+      options[:tags] || talent.tags
+    end
+    association :milestones, blueprint: MilestoneBlueprint, view: :normal
+    association :career_goal, blueprint: CareerGoalBlueprint, view: :normal
   end
 end

--- a/app/blueprints/token_blueprint.rb
+++ b/app/blueprints/token_blueprint.rb
@@ -1,3 +1,7 @@
 class TokenBlueprint < Blueprinter::Base
   fields :id, :contract_id, :ticker
+
+  view :normal do
+    fields :deployed
+  end
 end

--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -2,9 +2,14 @@ class UserBlueprint < Blueprinter::Base
   fields :id
 
   view :normal do
-    field :username
+    fields :username
     field :name do |user, _options|
       user.display_name || user.username
     end
+  end
+
+  view :extended do
+    include_view :normal
+    fields :email, :wallet_id
   end
 end

--- a/app/controllers/talent_controller.rb
+++ b/app/controllers/talent_controller.rb
@@ -1,5 +1,5 @@
 class TalentController < ApplicationController
-  before_action :set_talent, only: [:show, :update]
+  before_action :set_talent, only: [:show]
   before_action :set_outer_talent, only: [:edit_profile]
 
   def index
@@ -8,10 +8,12 @@ class TalentController < ApplicationController
   end
 
   def show
-    respond_to do |format|
-      format.html # show.html.erb
-      format.json { render json: @talent }
-    end
+    @talent = TalentBlueprint.render_as_json(
+      @talent,
+      view: :extended,
+      current_user: current_user,
+      tags: @talent.tags.where(hidden: false)
+    )
   end
 
   def edit_profile

--- a/app/packs/entrypoints/application.js
+++ b/app/packs/entrypoints/application.js
@@ -34,6 +34,7 @@ import NewPortfolio from "src/components/portfolio/NewPortfolio";
 import EditSupporter from "src/components/supporters/EditSupporter";
 import Discovery from "src/components/discovery";
 import TalentPage from "src/components/talent/TalentPage";
+import LoggedOutTopBar from "src/components/top_bar/LoggedOutTopBar";
 
 import "stylesheets/application.scss";
 
@@ -61,6 +62,7 @@ ReactOnRails.register({
   ChangePassword,
   Discovery,
   TalentPage,
+  LoggedOutTopBar,
 });
 
 Rails.start();

--- a/app/packs/src/components/design_system/typography/caption/index.jsx
+++ b/app/packs/src/components/design_system/typography/caption/index.jsx
@@ -1,14 +1,14 @@
 import React from "react";
-import { string, bool, oneOf, func } from "prop-types";
+import { string, number, bool, oneOfType, oneOf, func, node } from "prop-types";
 import cx from "classnames";
 
-const Caption = ({ bold, mode, text, className, onClick }) => {
+const Caption = ({ bold, mode, text, children, className, onClick }) => {
   return (
     <p
       className={cx("caption", bold ? "bold" : "", mode, className)}
       onClick={onClick}
     >
-      {text}
+      {text || children}
     </p>
   );
 };
@@ -18,14 +18,16 @@ Caption.defaultProps = {
   mode: "light",
   className: "",
   onClick: () => null,
+  children: null,
 };
 
 Caption.propTypes = {
   bold: bool,
   mode: oneOf(["light", "dark"]),
-  text: string.isRequired,
+  text: oneOfType([string, number]),
   className: string,
   onClick: func,
+  children: node,
 };
 
 export default Caption;

--- a/app/packs/src/components/design_system/typography/h1/index.jsx
+++ b/app/packs/src/components/design_system/typography/h1/index.jsx
@@ -1,10 +1,12 @@
 import React from "react";
-import { string, bool, oneOf } from "prop-types";
+import { string, number, bool, oneOfType, oneOf, node } from "prop-types";
 import cx from "classnames";
 
-const H1 = ({ bold, mode, text, className }) => {
+const H1 = ({ bold, mode, text, children, className }) => {
   return (
-    <h1 className={cx("h1", bold ? "bold" : "", mode, className)}>{text}</h1>
+    <h1 className={cx("h1", bold ? "bold" : "", mode, className)}>
+      {text || children}
+    </h1>
   );
 };
 
@@ -12,13 +14,15 @@ H1.defaultProps = {
   bold: false,
   mode: "light",
   className: "",
+  children: null,
 };
 
 H1.propTypes = {
   bold: bool,
   mode: oneOf(["light", "dark"]),
-  text: string.isRequired,
+  text: oneOfType([string, number]),
   className: string,
+  children: node,
 };
 
 export default H1;

--- a/app/packs/src/components/design_system/typography/h2/index.jsx
+++ b/app/packs/src/components/design_system/typography/h2/index.jsx
@@ -1,10 +1,12 @@
 import React from "react";
-import { string, bool, oneOf } from "prop-types";
+import { string, number, bool, oneOfType, oneOf, node } from "prop-types";
 import cx from "classnames";
 
-const H2 = ({ bold, mode, text, className }) => {
+const H2 = ({ bold, mode, text, children, className }) => {
   return (
-    <h2 className={cx("h2", bold ? "bold" : "", mode, className)}>{text}</h2>
+    <h2 className={cx("h2", bold ? "bold" : "", mode, className)}>
+      {text || children}
+    </h2>
   );
 };
 
@@ -12,13 +14,15 @@ H2.defaultProps = {
   bold: false,
   mode: "light",
   className: "",
+  children: null,
 };
 
 H2.propTypes = {
   bold: bool,
   mode: oneOf(["light", "dark"]),
-  text: string.isRequired,
+  text: oneOfType([string, number]),
   className: string,
+  children: node,
 };
 
 export default H2;

--- a/app/packs/src/components/design_system/typography/h3/index.jsx
+++ b/app/packs/src/components/design_system/typography/h3/index.jsx
@@ -1,10 +1,12 @@
 import React from "react";
-import { string, bool, oneOf } from "prop-types";
+import { string, number, bool, oneOfType, oneOf, node } from "prop-types";
 import cx from "classnames";
 
-const H3 = ({ bold, mode, text, className }) => {
+const H3 = ({ bold, mode, text, children, className }) => {
   return (
-    <h3 className={cx("h3", bold ? "bold" : "", mode, className)}>{text}</h3>
+    <h3 className={cx("h3", bold ? "bold" : "", mode, className)}>
+      {text || children}
+    </h3>
   );
 };
 
@@ -12,13 +14,15 @@ H3.defaultProps = {
   bold: false,
   mode: "light",
   className: "",
+  children: null,
 };
 
 H3.propTypes = {
   bold: bool,
   mode: oneOf(["light", "dark"]),
-  text: string.isRequired,
+  text: oneOfType([string, number]),
   className: string,
+  children: node,
 };
 
 export default H3;

--- a/app/packs/src/components/design_system/typography/h4/index.jsx
+++ b/app/packs/src/components/design_system/typography/h4/index.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { string, bool, oneOf, node } from "prop-types";
+import { string, number, bool, oneOfType, oneOf, node } from "prop-types";
 import cx from "classnames";
 
 const H4 = ({ bold, mode, text, children, className }) => {
@@ -14,12 +14,13 @@ H4.defaultProps = {
   bold: false,
   mode: "light",
   className: "",
+  children: null,
 };
 
 H4.propTypes = {
   bold: bool,
   mode: oneOf(["light", "dark"]),
-  text: string,
+  text: oneOfType([string, number]),
   children: node,
   className: string,
 };

--- a/app/packs/src/components/design_system/typography/h5/index.jsx
+++ b/app/packs/src/components/design_system/typography/h5/index.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { string, bool, oneOf, node } from "prop-types";
+import { string, number, bool, oneOfType, oneOf, node } from "prop-types";
 import cx from "classnames";
 
 const H5 = ({ bold, mode, text, children, className }) => {
@@ -14,12 +14,13 @@ H5.defaultProps = {
   bold: false,
   mode: "light",
   className: "",
+  children: null,
 };
 
 H5.propTypes = {
   bold: bool,
   mode: oneOf(["light", "dark"]),
-  text: string,
+  text: oneOfType([string, number]),
   children: node,
   className: string,
 };

--- a/app/packs/src/components/design_system/typography/p1/index.jsx
+++ b/app/packs/src/components/design_system/typography/p1/index.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { string, bool, oneOf, node } from "prop-types";
+import { string, number, bool, oneOfType, oneOf, node } from "prop-types";
 import cx from "classnames";
 
 const P1 = ({ bold, mode, text, children, className }) => {
@@ -14,12 +14,13 @@ P1.defaultProps = {
   bold: false,
   mode: "light",
   className: "",
+  children: null,
 };
 
 P1.propTypes = {
   bold: bool,
   mode: oneOf(["light", "dark"]),
-  text: string,
+  text: oneOfType([string, number]),
   children: node,
   className: string,
 };

--- a/app/packs/src/components/design_system/typography/p2/index.jsx
+++ b/app/packs/src/components/design_system/typography/p2/index.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { string, bool, oneOf, node } from "prop-types";
+import { string, number, bool, oneOfType, oneOf, node } from "prop-types";
 import cx from "classnames";
 
 const P2 = ({ bold, mode, text, children, className }) => {
@@ -14,12 +14,13 @@ P2.defaultProps = {
   bold: false,
   mode: "light",
   className: "",
+  children: null,
 };
 
 P2.propTypes = {
   bold: bool,
   mode: oneOf(["light", "dark"]),
-  text: string,
+  text: oneOfType([string, number]),
   children: node,
   className: string,
 };

--- a/app/packs/src/components/design_system/typography/p3/index.jsx
+++ b/app/packs/src/components/design_system/typography/p3/index.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { string, bool, oneOf, node } from "prop-types";
+import { string, number, bool, oneOfType, oneOf, node } from "prop-types";
 import cx from "classnames";
 
 const P3 = ({ bold, mode, text, children, className }) => {
@@ -21,7 +21,7 @@ P3.defaultProps = {
 P3.propTypes = {
   bold: bool,
   mode: oneOf(["light", "dark"]),
-  text: string,
+  text: oneOfType([string, number]),
   children: node,
   className: string,
 };

--- a/app/packs/src/components/icons/Logo.jsx
+++ b/app/packs/src/components/icons/Logo.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import Icon from "src/components/design_system/icon";
+
+const Logo = (props) => (
+  <Icon
+    path="M29.8 0L0 6.2V56l125-26.2V0L34.8 18.9c-2.6.5-5-1.4-5-4.1V0zm0 99.4c0-1.9 1.3-3.6 3.2-3.9l92-19.3V46.4L0 72.6V100c.3 34.2 28.2 61.9 62.5 61.9s62.2-27.7 62.5-61.9v-7.1l-29.8 6.2v.4c0 18.1-14.7 32.7-32.7 32.7-18.1-.1-32.7-14.7-32.7-32.8z"
+    fill="#7A55FF"
+    viewBox="0 0 125 162"
+    size={20}
+    {...props}
+  />
+);
+
+export default Logo;

--- a/app/packs/src/components/icons/index.jsx
+++ b/app/packs/src/components/icons/index.jsx
@@ -15,6 +15,7 @@ export { default as Help } from "src/components/icons/Help";
 export { default as Home } from "src/components/icons/Home";
 export { default as Img } from "src/components/icons/Img";
 export { default as List } from "src/components/icons/List";
+export { default as Logo } from "src/components/icons/Logo";
 export { default as LogoLight } from "src/components/icons/LogoLight";
 export { default as LogoDark } from "src/components/icons/LogoDark";
 export { default as LogoWord } from "src/components/icons/LogoWord";

--- a/app/packs/src/components/login/Login.jsx
+++ b/app/packs/src/components/login/Login.jsx
@@ -5,7 +5,7 @@ import Link from "../design_system/link";
 import { useTheme } from "src/contexts/ThemeContext";
 import { useWindowDimensionsHook } from "src/utils/window";
 import { H5, P2, P3 } from "../design_system/typography";
-import { TALENT_PROTOCOL_WEBSITE, USER_GUIDE } from "src/utils/constants";
+import { TALENT_APPLICATION_FORM, USER_GUIDE } from "src/utils/constants";
 import { post } from "src/utils/requests";
 import cx from "classnames";
 
@@ -91,7 +91,7 @@ const Login = () => {
           <Link
             bold
             target="_blank"
-            href={TALENT_PROTOCOL_WEBSITE}
+            href={TALENT_APPLICATION_FORM}
             text="Join the waitlist"
           />
         </div>

--- a/app/packs/src/components/talent/Show/SimpleTokenDetails.jsx
+++ b/app/packs/src/components/talent/Show/SimpleTokenDetails.jsx
@@ -1,0 +1,67 @@
+import React, { useState, useEffect } from "react";
+import { ethers } from "ethers";
+import currency from "currency.js";
+
+import { H4, P2 } from "src/components/design_system/typography";
+
+import {
+  ApolloProvider,
+  useQuery,
+  GET_TALENT_PORTFOLIO_FOR_ID_SIMPLE,
+  client,
+} from "src/utils/thegraph";
+
+const SimpleTokenDetails = ({ token, ticker }) => {
+  const { loading, data } = useQuery(GET_TALENT_PORTFOLIO_FOR_ID_SIMPLE, {
+    variables: { id: token?.contract_id?.toLowerCase() },
+  });
+
+  const [tokenData, setTokenData] = useState({
+    price: 0.1,
+    totalSupply: 0,
+    supporterCount: 0,
+  });
+
+  useEffect(() => {
+    if (loading || !data || !data.talentToken) {
+      return;
+    }
+
+    setTokenData({
+      ...tokenData,
+      totalSupply: ethers.utils.formatUnits(data.talentToken.totalSupply || 0),
+      supporterCount: data.talentToken.supporterCounter || 0,
+    });
+  }, [data, loading]);
+
+  const formatNumberWithSymbol = (value) => currency(value).format();
+
+  const formatNumberWithoutSymbol = (value) =>
+    currency(value, { symbol: "" }).format();
+
+  return (
+    <div>
+      <div className="card disabled d-flex flex-column align-items-center justify-content-center mb-5">
+        <P2 className="mb-2 text-primary-04" bold text="Market Value" />
+        <H4 bold text={formatNumberWithSymbol(tokenData.totalSupply * 0.1)} />
+      </div>
+      <div className="card disabled d-flex flex-column align-items-center justify-content-center mb-5">
+        <P2 className="mb-2 text-primary-04" bold text="Circulating Supply" />
+        <H4
+          bold
+          text={`${formatNumberWithoutSymbol(tokenData.totalSupply)} ${ticker}`}
+        />
+      </div>
+      <div className="card disabled d-flex flex-column align-items-center justify-content-center">
+        <P2 className="mb-2 text-primary-04" bold text="Supporters" />
+        <H4 bold text={tokenData.supporterCount} />
+      </div>
+    </div>
+  );
+};
+
+export default (props) => (
+  <ApolloProvider client={client(props.railsContext.contractsEnv)}>
+    <SimpleTokenDetails {...props} />
+  </ApolloProvider>
+);

--- a/app/packs/src/components/talent/Show/SimpleTokenDetails.jsx
+++ b/app/packs/src/components/talent/Show/SimpleTokenDetails.jsx
@@ -40,7 +40,7 @@ const SimpleTokenDetails = ({ token, ticker }) => {
     currency(value, { symbol: "" }).format();
 
   return (
-    <div>
+    <>
       <div className="card disabled d-flex flex-column align-items-center justify-content-center mb-5">
         <P2 className="mb-2 text-primary-04" bold text="Market Value" />
         <H4 bold text={formatNumberWithSymbol(tokenData.totalSupply * 0.1)} />
@@ -56,7 +56,7 @@ const SimpleTokenDetails = ({ token, ticker }) => {
         <P2 className="mb-2 text-primary-04" bold text="Supporters" />
         <H4 bold text={tokenData.supporterCount} />
       </div>
-    </div>
+    </>
   );
 };
 

--- a/app/packs/src/components/talent/TalentShow.jsx
+++ b/app/packs/src/components/talent/TalentShow.jsx
@@ -1,8 +1,5 @@
 import React, { useState, useEffect, useContext } from "react";
-import {
-  faStar as faStarOutline,
-  faEdit,
-} from "@fortawesome/free-regular-svg-icons";
+import { faStar as faStarOutline } from "@fortawesome/free-regular-svg-icons";
 import { faStar } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
@@ -50,6 +47,7 @@ const TalentShow = ({
   const searchParams = new URLSearchParams(url.search);
 
   const talentIsFromCurrentUser = talent.user_id == currentUserId;
+  const publicPageViewer = !currentUserId;
   const [pageInDisplay, setPageInDisplay] = useState("overview");
   const [show, setShow] = useState(false);
   const [changingFollow, setChangingFollow] = useState(false);
@@ -121,16 +119,18 @@ const TalentShow = ({
   };
 
   useEffect(() => {
-    if (searchParams.get("tab")) {
+    if (searchParams.get("tab") && !publicPageViewer) {
       setPageInDisplay(searchParams.get("tab"));
-    } else {
+    } else if (!publicPageViewer) {
       window.history.pushState(
         {},
         document.title,
         `${url.pathname}?tab=overview`
       );
+    } else if (publicPageViewer) {
+      window.history.pushState({}, document.title, url.pathname);
     }
-  }, [searchParams]);
+  }, [searchParams, publicPageViewer]);
 
   window.addEventListener("popstate", () => {
     const params = new URLSearchParams(document.location.search);
@@ -168,7 +168,7 @@ const TalentShow = ({
         type="white-subtle"
         mode={theme.mode()}
         className="mr-2 align-items-center"
-        disabled={user.messaging_enabled || (currentUserId == user.id)}
+        disabled={user.messaging_enabled || currentUserId == user.id}
       >
         {mobile && <Chat color="currentColor" className="mr-2" />}
         {!mobile && " Message"}
@@ -267,40 +267,42 @@ const TalentShow = ({
         </div>
         {!mobile && actionButtons()}
       </section>
-      <div
-        className={cx(
-          "talent-table-tabs mt-3 d-flex flex-row align-items-center",
-          mobile && "mx-4"
-        )}
-      >
+      {!publicPageViewer && (
         <div
-          onClick={() => changeTab("overview")}
-          className={`talent-table-tab${
-            pageInDisplay == "overview" ? " active-talent-table-tab" : ""
-          }`}
+          className={cx(
+            "talent-table-tabs mt-3 d-flex flex-row align-items-center",
+            mobile && "mx-4"
+          )}
         >
-          Overview
-        </div>
-        <div
-          onClick={() => changeTab("timeline")}
-          className={`talent-table-tab${
-            pageInDisplay == "timeline" ? " active-talent-table-tab" : ""
-          }`}
-        >
-          Timeline
-        </div>
-        {sharedState.token.contract_id && (
           <div
-            onClick={() => changeTab("supporters")}
+            onClick={() => changeTab("overview")}
             className={`talent-table-tab${
-              pageInDisplay == "supporters" ? " active-talent-table-tab" : ""
+              pageInDisplay == "overview" ? " active-talent-table-tab" : ""
             }`}
           >
-            Supporters
+            Overview
           </div>
-        )}
-      </div>
-      <div className={cx("d-flex flex-row flex-wrap", mobile && "pl-4")}>
+          <div
+            onClick={() => changeTab("timeline")}
+            className={`talent-table-tab${
+              pageInDisplay == "timeline" ? " active-talent-table-tab" : ""
+            }`}
+          >
+            Timeline
+          </div>
+          {sharedState.token.contract_id && (
+            <div
+              onClick={() => changeTab("supporters")}
+              className={`talent-table-tab${
+                pageInDisplay == "supporters" ? " active-talent-table-tab" : ""
+              }`}
+            >
+              Supporters
+            </div>
+          )}
+        </div>
+      )}
+      <div className={cx("d-flex flex-row flex-wrap", mobile && "px-4")}>
         <div
           className={`col-12${
             pageInDisplay != "supporters" ? " col-lg-8" : ""
@@ -335,7 +337,7 @@ const TalentShow = ({
         )}
       </div>
       {pageInDisplay == "overview" && (
-        <section className={cx("d-flex flex-column my-3", mobile && "pl-4")}>
+        <section className={cx("d-flex flex-column my-3", mobile && "px-4")}>
           <Roadmap
             goals={sharedState.goals}
             width={width}

--- a/app/packs/src/components/talent/TalentShow.jsx
+++ b/app/packs/src/components/talent/TalentShow.jsx
@@ -127,7 +127,7 @@ const TalentShow = ({
         document.title,
         `${url.pathname}?tab=overview`
       );
-    } else if (publicPageViewer) {
+    } else {
       window.history.pushState({}, document.title, url.pathname);
     }
   }, [searchParams, publicPageViewer]);

--- a/app/packs/src/components/talent/TalentShow.jsx
+++ b/app/packs/src/components/talent/TalentShow.jsx
@@ -232,7 +232,7 @@ const TalentShow = ({
               height={mobile ? 120 : 192}
               border
             />
-            {mobile && actionButtons()}
+            {mobile && !publicPageViewer && actionButtons()}
           </div>
           <div className={cx("d-flex flex-column", !mobile && "ml-5")}>
             <div className="d-flex flex-row flex-wrap align-items-center justify-content-start mt-3 mt-lg-0">
@@ -265,7 +265,7 @@ const TalentShow = ({
             {mobile && <SocialRow sharedState={sharedState} />}
           </div>
         </div>
-        {!mobile && actionButtons()}
+        {!mobile && !publicPageViewer && actionButtons()}
       </section>
       {!publicPageViewer && (
         <div

--- a/app/packs/src/components/talent/TalentShow.jsx
+++ b/app/packs/src/components/talent/TalentShow.jsx
@@ -16,7 +16,7 @@ import Supporters from "./Show/Supporters";
 
 import Roadmap from "./Show/Roadmap";
 import Perks from "./Show/Perks";
-import TokenDetails from "./Show/TokenDetails";
+import SimpleTokenDetails from "./Show/SimpleTokenDetails";
 import SocialRow from "./Show/SocialRow";
 
 import Button from "src/components/design_system/button";
@@ -324,14 +324,11 @@ const TalentShow = ({
           )}
         </div>
         {pageInDisplay != "supporters" && (
-          <div className="col-12 col-lg-4 p-0 mb-4">
-            <TokenDetails
+          <div className="col-12 col-lg-4 p-0 mt-4">
+            <SimpleTokenDetails
               ticker={ticker()}
               token={token}
-              displayName={displayName({ withLink: false })}
-              username={sharedState.user.username}
               railsContext={railsContext}
-              mobile={mobile}
             />
           </div>
         )}

--- a/app/packs/src/components/top_bar/LoggedOutTopBar.jsx
+++ b/app/packs/src/components/top_bar/LoggedOutTopBar.jsx
@@ -11,7 +11,6 @@ export const LoggedOutTopBar = ({}) => {
   const { mobile } = useWindowDimensionsHook();
   const { simpleToggleTheme, mode } = useTheme();
 
-  console.log(mode());
   return (
     <div className="navbar-container">
       <nav className={`navbar d-flex justify-content-between`}>

--- a/app/packs/src/components/top_bar/LoggedOutTopBar.jsx
+++ b/app/packs/src/components/top_bar/LoggedOutTopBar.jsx
@@ -1,0 +1,66 @@
+import React, { useState, useEffect, useCallback, useContext } from "react";
+import { useWindowDimensionsHook } from "src/utils/window";
+import ThemeContainer, { useTheme } from "src/contexts/ThemeContext";
+import { TALENT_PROTOCOL_WEBSITE } from "src/utils/constants";
+
+import { LogoLight, LogoDark, Logo } from "src/components/icons";
+import Button from "src/components/design_system/button";
+import { Sun, Moon } from "src/components/icons";
+
+export const LoggedOutTopBar = ({}) => {
+  const { mobile } = useWindowDimensionsHook();
+  const { simpleToggleTheme, mode } = useTheme();
+
+  console.log(mode());
+  return (
+    <div className="navbar-container">
+      <nav className={`navbar d-flex justify-content-between`}>
+        <div className="d-flex align-items-center" style={{ height: 34 }}>
+          {mobile ? (
+            <Logo />
+          ) : (
+            <a href="/" className="mr-6" style={{ height: 30 }}>
+              {mode() == "light" ? (
+                <LogoLight width={128} height={20} />
+              ) : (
+                <LogoDark width={128} height={20} />
+              )}
+            </a>
+          )}
+        </div>
+        <div className="d-flex" style={{ height: 34 }}>
+          <Button
+            type="primary-default"
+            onClick={() => window.open(TALENT_PROTOCOL_WEBSITE)}
+            text="Join Waitlist"
+          />
+          <Button
+            type="white-subtle"
+            onClick={() => (window.location.href = "/")}
+            className="ml-2"
+            text="Sign in"
+          />
+          <Button
+            type="white-subtle"
+            onClick={simpleToggleTheme}
+            className="text-black ml-2"
+          >
+            {mode() === "light" ? (
+              <Moon color="currentColor" />
+            ) : (
+              <Sun color="currentColor" />
+            )}
+          </Button>
+        </div>
+      </nav>
+    </div>
+  );
+};
+
+export default (props, railsContext) => {
+  return () => (
+    <ThemeContainer {...props}>
+      <LoggedOutTopBar {...props} railsContext={railsContext} />
+    </ThemeContainer>
+  );
+};

--- a/app/packs/src/components/top_bar/LoggedOutTopBar.jsx
+++ b/app/packs/src/components/top_bar/LoggedOutTopBar.jsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, useCallback, useContext } from "react";
+import React from "react";
 import { useWindowDimensionsHook } from "src/utils/window";
 import ThemeContainer, { useTheme } from "src/contexts/ThemeContext";
-import { TALENT_PROTOCOL_WEBSITE } from "src/utils/constants";
+import { TALENT_APPLICATION_FORM } from "src/utils/constants";
 
 import { LogoLight, LogoDark, Logo } from "src/components/icons";
 import Button from "src/components/design_system/button";
@@ -30,7 +30,7 @@ export const LoggedOutTopBar = ({}) => {
         <div className="d-flex" style={{ height: 34 }}>
           <Button
             type="primary-default"
-            onClick={() => window.open(TALENT_PROTOCOL_WEBSITE)}
+            onClick={() => window.open(TALENT_APPLICATION_FORM)}
             text="Join Waitlist"
           />
           <Button

--- a/app/packs/src/utils/constants.js
+++ b/app/packs/src/utils/constants.js
@@ -27,6 +27,9 @@ export const TALENT_PROTOCOL_DISCORD = "https://discord.gg/talentprotocol";
 
 export const TALENT_PROTOCOL_WEBSITE = "https://www.talentprotocol.com";
 
+export const TALENT_APPLICATION_FORM =
+  "https://talentprotocol.typeform.com/apply";
+
 export const ERROR_MESSAGES = {
   ticker_reserved: "talent token with this symbol already exists",
   action_canceled: "User denied transaction signature",

--- a/app/views/talent/show.html.erb
+++ b/app/views/talent/show.html.erb
@@ -8,19 +8,25 @@
     <% end %>
     <%= react_component("TalentShow", props:
       {
-        talent: @talent.as_json,
-        profilePictureUrl: @talent.profile_picture_url,
-        bannerUrl: @talent.banner_url,
-        tags: @talent.tags.where(hidden: false).map(&:description),
-        token: @talent.token.as_json,
-        perks: @talent.perks.as_json,
-        careerGoal: @talent.career_goal.as_json,
-        goals: @talent.career_goal.present? ? @talent.career_goal&.goals.order(:due_date) : [],
-        milestones: @talent.milestones.as_json,
+        talent: @talent,
+        profilePictureUrl: @talent["profile_picture_url"],
+        bannerUrl: @talent["banner_url"],
+        tags: @talent["tags"].map { |tag| tag["description"] },
+        token: @talent["token"],
+        perks: @talent["perks"],
+        careerGoal: @talent["career_goal"],
+        goals: @talent["career_goal"]["goals"],
+        milestones: @talent["milestones"],
         currentUserId: current_user&.id,
-        tokenLive: @talent.token.deployed?,
-        isFollowing: current_user ? current_user.following.where(user_id: @talent.user_id).exists? : nil,
-        user: { id: @talent.user_id, email: @talent.user.email, username: @talent.user.username, display_name: @talent.user.display_name, wallet_id: @talent.user.wallet_id },
+        tokenLive: @talent["token"]["deployed"],
+        isFollowing: @talent["is_following"],
+        user: {
+          id: @talent["user_id"],
+          email: @talent["user"]["email"],
+          username: @talent["user"]["username"],
+          display_name: @talent["user"]["display_name"],
+          wallet_id: @talent["user"]["wallet_id"]
+        },
       }, prerender: false)
     %>
   </div>

--- a/app/views/talent/show.html.erb
+++ b/app/views/talent/show.html.erb
@@ -1,5 +1,11 @@
 <main class="main-content">
   <div class="container-grid">
+    <% if current_user.nil? %>
+      <%= react_component("LoggedOutTopBar", props:
+        {
+        }, prerender: false)
+      %>
+    <% end %>
     <%= react_component("TalentShow", props:
       {
         talent: @talent.as_json,
@@ -11,9 +17,9 @@
         careerGoal: @talent.career_goal.as_json,
         goals: @talent.career_goal.present? ? @talent.career_goal&.goals.order(:due_date) : [],
         milestones: @talent.milestones.as_json,
-        currentUserId: current_user.id,
+        currentUserId: current_user&.id,
         tokenLive: @talent.token.deployed?,
-        isFollowing: current_user.following.where(user_id: @talent.user_id).exists?,
+        isFollowing: current_user ? current_user.following.where(user_id: @talent.user_id).exists? : nil,
         user: { id: @talent.user_id, email: @talent.user.email, username: @talent.user.username, display_name: @talent.user.display_name, wallet_id: @talent.user.wallet_id },
       }, prerender: false)
     %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,9 +18,7 @@ Rails.application.routes.draw do
     end
 
     # Talent pages & search
-    get "/talent/active", to: "talent/searches#active"
-    get "/talent/upcoming", to: "talent/searches#upcoming"
-    resources :talent, only: [:index, :show] do
+    resources :talent, only: [:index] do
       get :edit_profile
     end
 
@@ -75,6 +73,7 @@ Rails.application.routes.draw do
       controller: "passwords",
       only: [:edit, :update]
   end
+  resources :talent, only: [:show]
 
   get "/sign_up" => "pages#home", :as => :sign_up
   get "/" => "sessions#new", :as => "sign_in"


### PR DESCRIPTION
## Summary
Create a public lite profile page

### What changed?
A new navbar for not logged in users
Talent profile accessible by anyone
Hide all tabs but "overview"
Create a new token details component
Remove actionable buttons for public page

## Notion link
https://www.notion.so/talentprotocol/Public-Profile-lite-version-2-2-45183d7094004beab55852fe3e3b16e6

## How to test?
Open a talent's page while logged in and while logged out.
Check if buttons and tabs appear when logged in and don't appear when logged out
