### PR TITLE
Don't allow uppercase letters on username

### DIFF
--- a/app/packs/src/components/registration/RegisterUsername.jsx
+++ b/app/packs/src/components/registration/RegisterUsername.jsx
@@ -16,7 +16,7 @@ const RegisterUsername = ({ themePreference, changeUsername, changeStep }) => {
   const invalidForm = !usernameValidated || usernameError;
 
   const editUsername = (e) => {
-    if (e.target.value != "" && !/^[A-Za-z0-9]+$/.test(e.target.value)) {
+    if (e.target.value != "" && !/^[a-z0-9]+$/.test(e.target.value)) {
       setUsernameError(true);
     } else {
       setUsernameError(false);


### PR DESCRIPTION
## Summary

On users controller we were checking against the validity of the username and usernames with uppercase letters aren't allowed. In the past we were forcing this only on save and so the frontend allowed for upper case letters because it would downcase. But with this new follow that is no longer possible.