### PR TITLE
Fix source id lookup

### DIFF
--- a/app/notifications/base_notification.rb
+++ b/app/notifications/base_notification.rb
@@ -16,12 +16,8 @@ class BaseNotification < Noticed::Base
   end
 
   def source
-    if @source_loaded
-      @source
-    else
-      @source_loaded = true
-      @source = User.find_by(id: params["source_id"])
-    end
+    @source ||=
+      User.find_by(id: params.params["source_id"])
   end
 
   def source_name

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,6 +64,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
   config.action_mailer.default_url_options = {host: ENV.fetch("EMAIL_ENV", "dev") + ".talentprotocol.com"}
+  routes.default_url_options[:host] = ENV.fetch("EMAIL_ENV", "dev") + ".talentprotocol.com"
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
## Summary

the source of the notification was not being correctly calculated and we were missing a default URL option on the prod config