### PR TITLE
Display links in messages

### DIFF
--- a/app/packs/src/components/chat/Message.jsx
+++ b/app/packs/src/components/chat/Message.jsx
@@ -1,9 +1,20 @@
 import React from "react";
 import dayjs from "dayjs";
+import { LinkItEmail, LinkItUrl } from 'react-linkify-it';
 
 import TalentProfilePicture from "../talent/TalentProfilePicture";
 import P2 from "src/components/design_system/typography/p2";
 import P3 from "src/components/design_system/typography/p3";
+
+const MessageLinkified = (props) => {
+  return (
+    <LinkItUrl>
+      <LinkItEmail>
+          {props.message}
+      </LinkItEmail>
+    </LinkItUrl>
+  )
+}
 
 const Message = (props) => {
   const {
@@ -43,7 +54,9 @@ const Message = (props) => {
             <P3 text={sentDate} className="mb-0 ml-2" />
           </div>
         )}
-        <P2 text={message.text} className={"text-white-space-wrap"} />
+        <P2 className={"text-white-space-wrap"}>
+          <MessageLinkified message={message.text}/>
+        </P2>
       </div>
     </div>
   );

--- a/app/packs/src/components/chat/Message.jsx
+++ b/app/packs/src/components/chat/Message.jsx
@@ -1,18 +1,87 @@
-import React from "react";
+import React, { useState } from "react";
 import dayjs from "dayjs";
-import { LinkItEmail, LinkItUrl } from 'react-linkify-it';
+import Modal from "react-bootstrap/Modal";
+import { LinkIt, LinkItEmail, urlRegex } from 'react-linkify-it';
 
 import TalentProfilePicture from "../talent/TalentProfilePicture";
-import P2 from "src/components/design_system/typography/p2";
-import P3 from "src/components/design_system/typography/p3";
+import { P1, P2, P3 } from "src/components/design_system/typography";
+
+export const PhisingAwarenessModal = ({ show, hide, url }) => (
+    <Modal show={show} onHide={hide} centered dialogClassName="remove-background">
+      <Modal.Body className="p-4">
+        <P1
+          bold
+          text="Before you go"
+          className="mb-4">
+        </P1>
+        <P2
+          text="Always double check that the links that were sent to you are legitimate. It's a dangerous world out there."
+          className="mb-2"
+          >
+        </P2>
+        <a
+          className="mb-6"
+          href={url}
+          >
+            {url}
+        </a>
+        <div class="d-flex flex-row justify-content-between align-items-center mt-4">
+          <button
+              className="talent-button white-subtle-button normal-size-button w-100 mr-2"
+              onClick={hide}
+            >
+            Cancel
+          </button>
+          <a
+            className="btn talent-button primary-default-button normal-size-button w-100 ml-2"
+            href={url}
+            target="_blank"
+            onClick={hide}
+          >
+            I Understand
+          </a>
+        </div>
+      </Modal.Body>
+    </Modal>
+);
 
 const MessageLinkified = (props) => {
+  const [showPishingModal, setShowPishingModal] = useState(false);
+  const [url, setUrl] = useState('');
+
+  const {
+    message,
+    mine
+  } = props;
+
+  const handleClick = (e, url) => {
+    if(mine) {
+      return
+    }
+    e.preventDefault();
+    setShowPishingModal(true);
+    setUrl(e.target.origin)
+  };
+
   return (
-    <LinkItUrl>
+    <LinkIt
+      component={(match, key) => (
+        <a
+          href={match}
+          key={key}
+          target="_blank"
+          onClick={handleClick}
+        >
+          {match}
+        </a>
+      )}
+      regex={urlRegex}
+    >
       <LinkItEmail>
-          {props.message}
+        { !mine && <PhisingAwarenessModal url={url} show={showPishingModal} hide={() => setShowPishingModal(false)} /> }
+        {message}
       </LinkItEmail>
-    </LinkItUrl>
+    </LinkIt>
   )
 }
 
@@ -55,7 +124,7 @@ const Message = (props) => {
           </div>
         )}
         <P2 className={"text-white-space-wrap"}>
-          <MessageLinkified message={message.text}/>
+          <MessageLinkified message={message.text} mine={mine}/>
         </P2>
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-bootstrap": "^1.6.0",
     "react-dom": "^17.0.2",
     "react-google-recaptcha": "^2.1.0",
+    "react-linkify-it": "^1.0.4",
     "react-on-rails": "12.2.0",
     "react-player": "^2.9.0",
     "regenerator-runtime": "^0.13.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11725,6 +11725,11 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-linkify-it@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/react-linkify-it/-/react-linkify-it-1.0.4.tgz#58fd2bb63763f1dc888019d9b82339af8d600e93"
+  integrity sha512-/XNtL2DNzhjBu60aUZ119uUBsV7tWUYcQjIU/Tti6B29h7QR1I+0Q/u84vUKfT0BIEeHbe41KgvkufKBxfNInw==
+
 react-on-rails@12.2.0:
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/react-on-rails/-/react-on-rails-12.2.0.tgz#289d3752f695be7a9e71c8075a2601029e1ac71e"


### PR DESCRIPTION
## Summary

<img width="1476" alt="Screenshot 2022-03-07 at 09 12 33" src="https://user-images.githubusercontent.com/8901722/157001718-74a79134-2572-4c21-87f5-347c14874b3b.png">

<img width="1539" alt="Screenshot 2022-03-14 at 20 13 37" src="https://user-images.githubusercontent.com/8901722/158253792-f38e8ca4-4c30-405d-b190-75614201d3af.png">


### What changed?

It's now possible to have clickable links in the chat.

### Why it changed?

Adds more usability to the chat. No need to copy and paste urls.

### How it changed?

Added a lib (https://github.com/anantoghosh/react-linkify-it) to detect urls and make them clickable.

## Notion link

https://www.notion.so/Prevent-phising-links-on-chat-a1e9488901514ce193b25776bd3535b9

## How to test?

Send links, twitter handles and emails and check they open correctly.

## Notes

We might want to add whitelisted URLs in the future. Right now the user needs to confirm  link every time he clicks it.