### PR TITLE
Add supporting tab to talent page

### DIFF
--- a/app/packs/src/components/talent/Show/Supporters.jsx
+++ b/app/packs/src/components/talent/Show/Supporters.jsx
@@ -183,8 +183,8 @@ const Supporters = ({ mobile, mode, sharedState }) => {
   if (!loading && sortedSupporters().length == 0) {
     return (
       <div className="w-100 h-100 d-flex flex-column justify-content-center align-items-center mt-3">
-        <H5 text="You don't have any Supporter" bold />
-        <P2 text="All your supporters will be listed here" bold />
+        <H5 text="There's no supporters" bold />
+        <P2 text="All supporters will be listed here" bold />
       </div>
     );
   }
@@ -240,8 +240,12 @@ const Supporters = ({ mobile, mode, sharedState }) => {
             {sortedSupporters().map((supporter) => (
               <Table.Tr
                 key={`supporter-${supporter.id}`}
-                className="px-2"
-                onClick={() => console.log("SHOW SUPPORTER DETAILS")}
+                className="px-2 cursor-pointer"
+                onClick={() =>
+                  (window.location.href = `/u/${
+                    supporterInfo[supporter.id]?.username
+                  }`)
+                }
               >
                 <Table.Td>
                   <div className="d-flex cursor-pointer py-2">
@@ -269,10 +273,10 @@ const Supporters = ({ mobile, mode, sharedState }) => {
 
   return (
     <>
-      <P1 className="mt-5" bold>
+      <H5 className="mt-5 mb-6" bold>
         Supporters
-      </P1>
-      <Table mode={mode} className="px-3 horizontal-scroll mt-3 mb-4">
+      </H5>
+      <Table mode={mode} className="px-3 horizontal-scroll mb-4">
         <Table.Head>
           <Table.Th>
             <Caption
@@ -295,7 +299,12 @@ const Supporters = ({ mobile, mode, sharedState }) => {
           {sortedSupporters().map((supporter) => (
             <Table.Tr
               key={`supporter-${supporter.id}`}
-              className="reset-cursor"
+              className="cursor-pointer"
+              onClick={() =>
+                (window.location.href = `/u/${
+                  supporterInfo[supporter.id]?.username
+                }`)
+              }
             >
               <Table.Td>
                 <div className="d-flex flex-row">

--- a/app/packs/src/components/talent/TalentShow.jsx
+++ b/app/packs/src/components/talent/TalentShow.jsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect, useContext } from "react";
+import { post, destroy } from "src/utils/requests";
+
 import { faStar as faStarOutline } from "@fortawesome/free-regular-svg-icons";
 import { faStar } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-import { post, destroy } from "src/utils/requests";
 import { useWindowDimensionsHook } from "../../utils/window";
 import TalentProfilePicture from "./TalentProfilePicture";
 
@@ -13,6 +14,7 @@ import UserTags from "./UserTags";
 import Overview from "./Show/Overview";
 import Timeline from "./Show/Timeline";
 import Supporters from "./Show/Supporters";
+import Supporting from "src/components/supporters/show/Supporting";
 
 import Roadmap from "./Show/Roadmap";
 import Perks from "./Show/Perks";
@@ -120,18 +122,16 @@ const TalentShow = ({
   };
 
   useEffect(() => {
-    if (searchParams.get("tab") && !publicPageViewer) {
+    if (searchParams.get("tab")) {
       setPageInDisplay(searchParams.get("tab"));
-    } else if (!publicPageViewer) {
+    } else {
       window.history.pushState(
         {},
         document.title,
         `${url.pathname}?tab=overview`
       );
-    } else {
-      window.history.pushState({}, document.title, url.pathname);
     }
-  }, [searchParams, publicPageViewer]);
+  }, [searchParams]);
 
   window.addEventListener("popstate", () => {
     const params = new URLSearchParams(document.location.search);
@@ -295,45 +295,53 @@ const TalentShow = ({
         </div>
         {!mobile && !publicPageViewer && actionButtons()}
       </section>
-      {!publicPageViewer && (
+      <div
+        className={cx(
+          "talent-table-tabs mt-3 d-flex flex-row align-items-center",
+          mobile && "mx-4"
+        )}
+      >
         <div
-          className={cx(
-            "talent-table-tabs mt-3 d-flex flex-row align-items-center",
-            mobile && "mx-4"
-          )}
+          onClick={() => changeTab("overview")}
+          className={`talent-table-tab${
+            pageInDisplay == "overview" ? " active-talent-table-tab" : ""
+          }`}
         >
-          <div
-            onClick={() => changeTab("overview")}
-            className={`talent-table-tab${
-              pageInDisplay == "overview" ? " active-talent-table-tab" : ""
-            }`}
-          >
-            Overview
-          </div>
-          <div
-            onClick={() => changeTab("timeline")}
-            className={`talent-table-tab${
-              pageInDisplay == "timeline" ? " active-talent-table-tab" : ""
-            }`}
-          >
-            Timeline
-          </div>
-          {sharedState.token.contract_id && (
-            <div
-              onClick={() => changeTab("supporters")}
-              className={`talent-table-tab${
-                pageInDisplay == "supporters" ? " active-talent-table-tab" : ""
-              }`}
-            >
-              Supporters
-            </div>
-          )}
+          Overview
         </div>
-      )}
+        <div
+          onClick={() => changeTab("timeline")}
+          className={`talent-table-tab${
+            pageInDisplay == "timeline" ? " active-talent-table-tab" : ""
+          }`}
+        >
+          Timeline
+        </div>
+        {sharedState.token.contract_id && (
+          <div
+            onClick={() => changeTab("supporters")}
+            className={`talent-table-tab${
+              pageInDisplay == "supporters" ? " active-talent-table-tab" : ""
+            }`}
+          >
+            Supporters
+          </div>
+        )}
+        <div
+          onClick={() => changeTab("supporting")}
+          className={`talent-table-tab${
+            pageInDisplay == "supporting" ? " active-talent-table-tab" : ""
+          }`}
+        >
+          Supporting
+        </div>
+      </div>
       <div className={cx("d-flex flex-row flex-wrap", mobile && "px-4")}>
         <div
           className={`col-12${
-            pageInDisplay != "supporters" ? " col-lg-8" : ""
+            pageInDisplay != "supporters" && pageInDisplay != "supporting"
+              ? " col-lg-8"
+              : ""
           } p-0`}
         >
           {pageInDisplay == "overview" && (
@@ -355,8 +363,19 @@ const TalentShow = ({
               railsContext={railsContext}
             />
           )}
+          {pageInDisplay == "supporting" && (
+            <div className="mt-5">
+              <Supporting
+                wallet={user.wallet_id}
+                publicPageViewer={publicPageViewer}
+                withOptions={false}
+                listMode={true}
+                railsContext={railsContext}
+              />
+            </div>
+          )}
         </div>
-        {pageInDisplay != "supporters" && (
+        {pageInDisplay != "supporters" && pageInDisplay != "supporting" && (
           <div className="col-12 col-lg-4 p-0 mt-4">
             <SimpleTokenDetails
               ticker={ticker()}

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -257,8 +257,8 @@ ActiveRecord::Schema.define(version: 2022_03_16_152458) do
     t.boolean "welcome_pop_up", default: false
     t.boolean "tokens_purchased", default: false
     t.boolean "token_purchase_reminder_sent", default: false
-    t.boolean "disabled", default: false
     t.string "theme_preference", default: "light"
+    t.boolean "disabled", default: false
     t.boolean "messaging_disabled", default: false
     t.jsonb "notification_preferences", default: {}
     t.string "user_nft_address"


### PR DESCRIPTION
## Summary

Add Supporting tab to Talent profile
Each row of Supporters and Supporting should be clickable since all users have profiles now
Show all tabs on talent’s public profile

## Notion link

<!--- Link to the Notion task. -->

## How to test?
Open talent page logged in and logged out and see if everything looks alright
Open supporter page logged in and logged out and see if everything looks alright

## Notes

<!--- Notes you might consider worth adding. -->