### PR TITLE
Store token information if user has NFT

### DIFF
--- a/app/services/web3/MintUserNFT.rb
+++ b/app/services/web3/MintUserNFT.rb
@@ -18,6 +18,12 @@ module Web3
             user_nft_token_id: response["body"]["tokenId"],
             user_nft_tx: response["body"]["tx"]
           )
+        elsif response["statusCode"] == 400 && response["errorId"] == 2
+          user.update!(
+            user_nft_minted: true,
+            user_nft_address: response["body"]["tokenAddress"],
+            user_nft_token_id: response["body"]["tokenId"]
+          )
         else
           log_error(user)
           false


### PR DESCRIPTION
## Summary

To make sure that we don't send more than one NFT to a user if a user deletes an account and creates a new one we need to return the tokenId and address from the lambda call