### PR TITLE
Discovery page fixes

### DIFF
--- a/app/packs/src/components/design_system/cards/NewTalentCard.jsx
+++ b/app/packs/src/components/design_system/cards/NewTalentCard.jsx
@@ -32,65 +32,10 @@ const NewTalentCard = ({
     updateFollow();
   };
 
-  return (
-    <div
-      className="talent-card"
-      onMouseEnter={() => setShowUserDetails(true)}
-      onMouseLeave={() => setShowUserDetails(false)}
-    >
-      {!showUserDetails || mobile ? (
-        <a className="talent-card-title talent-link" href={talentLink}>
-          <div className="d-flex flex-column align-items-center">
-            <TalentProfilePicture src={profilePictureUrl} height={120} />
-            <H5 className="text-black mt-3 talent-card-name" bold text={name} />
-            <P2
-              className="text-primary-03 talent-card-occupation"
-              text={occupation}
-            />
-          </div>
-          {contractId ? (
-            <P2 className="text-primary" bold text={`$${ticker}`} />
-          ) : (
-            <Tag className="coming-soon-tag">
-              <P3 className="current-color" bold text="Coming Soon" />
-            </Tag>
-          )}
-        </a>
-      ) : (
-        <a className="talent-card-details talent-link" href={talentLink}>
-          <div className="d-flex justify-content-between align-items-start w-100">
-            <div className="d-flex align-items-center">
-              <TalentProfilePicture src={profilePictureUrl} height={32} />
-              <div className="d-flex flex-column ml-3">
-                <P2
-                  className="text-black talent-card-details-title"
-                  bold
-                  text={name}
-                />
-                <P3
-                  className="text-primary-03 talent-card-details-title"
-                  text={occupation}
-                />
-              </div>
-            </div>
-            {!publicPageViewer && (
-              <button
-                className="button-link ml-2"
-                onClick={(e) => updateFollowing(e)}
-              >
-                <Star pathClassName={isFollowing ? "star" : "star-outline"} />
-              </button>
-            )}
-          </div>
-          <P1
-            className="text-black talent-card-details-headline mt-3"
-            bold
-            text={headline}
-          />
-        </a>
-      )}
+  const talentCardFooter = () => (
+    <>
       <Divider />
-      <div className="talent-card-body">
+      <div className="talent-card-footer">
         <div className="d-flex justify-content-between">
           <P3 className="text-primary-04" text="Market cap" />
           <P3 className="text-primary-04" text="Supporters" />
@@ -106,6 +51,76 @@ const NewTalentCard = ({
           />
         </div>
       </div>
+    </>
+  );
+
+  return (
+    <div
+      className="talent-card"
+      onMouseEnter={() => setShowUserDetails(true)}
+      onMouseLeave={() => setShowUserDetails(false)}
+    >
+      {!showUserDetails || mobile ? (
+        <a className="talent-link" href={talentLink}>
+          <div className="talent-card-title">
+            <div className="d-flex flex-column align-items-center">
+              <TalentProfilePicture src={profilePictureUrl} height={120} />
+              <H5
+                className="text-black mt-3 talent-card-name"
+                bold
+                text={name}
+              />
+              <P2
+                className="text-primary-03 talent-card-occupation"
+                text={occupation}
+              />
+            </div>
+            {contractId ? (
+              <P2 className="text-primary" bold text={`$${ticker}`} />
+            ) : (
+              <Tag className="coming-soon-tag">
+                <P3 className="current-color" bold text="Coming Soon" />
+              </Tag>
+            )}
+          </div>
+          {talentCardFooter()}
+        </a>
+      ) : (
+        <a className="talent-link" href={talentLink}>
+          <div className="talent-card-details">
+            <div className="d-flex justify-content-between align-items-start w-100">
+              <div className="d-flex align-items-center">
+                <TalentProfilePicture src={profilePictureUrl} height={32} />
+                <div className="d-flex flex-column ml-3">
+                  <P2
+                    className="text-black talent-card-details-title"
+                    bold
+                    text={name}
+                  />
+                  <P3
+                    className="text-primary-03 talent-card-details-title"
+                    text={occupation}
+                  />
+                </div>
+              </div>
+              {!publicPageViewer && (
+                <button
+                  className="button-link ml-2"
+                  onClick={(e) => updateFollowing(e)}
+                >
+                  <Star pathClassName={isFollowing ? "star" : "star-outline"} />
+                </button>
+              )}
+            </div>
+            <P1
+              className="text-black talent-card-details-headline mt-3"
+              bold
+              text={headline}
+            />
+          </div>
+          {talentCardFooter()}
+        </a>
+      )}
     </div>
   );
 };

--- a/app/packs/src/components/discovery/discovery_rows.jsx
+++ b/app/packs/src/components/discovery/discovery_rows.jsx
@@ -132,7 +132,7 @@ const DiscoveryRows = ({ discoveryRows, updateFollow }) => {
               </div>
               <div
                 className={cx(
-                  "w-100 d-flex horizontal-scroll hide-scrollbar talents-cards-container justify-start pb-6",
+                  "w-100 d-flex hide-scrollbar talents-cards-container justify-start pb-6",
                   mobile && "pl-4"
                 )}
               >

--- a/app/packs/src/components/discovery/index.jsx
+++ b/app/packs/src/components/discovery/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useMemo, useState, useCallback } from "react";
 
 import { post, destroy } from "src/utils/requests";
 import { useWindowDimensionsHook } from "src/utils/window";
@@ -27,12 +27,16 @@ const Discovery = ({ discoveryRows, marketingArticles }) => {
   const [localDiscoveryRows, setLocalDiscoveryRows] = useState(discoveryRows);
   const [loading, setLoading] = useState(true);
 
-  const talentIdsPerRow = discoveryRows.reduce((acc, curr) => {
-    if (curr.talents.length > 0) {
-      return { ...acc, [curr.title]: curr.talents.map((t) => t.id) };
-    }
-    return { ...acc };
-  }, {});
+  const talentIdsPerRow = useMemo(
+    () =>
+      discoveryRows.reduce((acc, curr) => {
+        if (curr.talents.length > 0) {
+          return { ...acc, [curr.title]: curr.talents.map((t) => t.id) };
+        }
+        return { ...acc };
+      }, {}),
+    [discoveryRows]
+  );
 
   const addTokenDetails = useCallback((talents, talentsFromChain) => {
     const newArray = talents.map((talent) => {

--- a/app/packs/src/onchain/addresses.json
+++ b/app/packs/src/onchain/addresses.json
@@ -1,7 +1,7 @@
 {
   "development": {
-    "factory": "0x709A9a5a920EaDec04Eaa75ACe3a19e6605c44E4",
-    "staking": "0xAdD7B6AB1d746a98EFB8C8d6f17158Db95081D65",
+    "factory": "0x65551F75D8365AC2956481BF1a5642159e108AE4",
+    "staking": "0x863b3a1c02B479438180A26854Fb982DaC520aD8",
     "forno": "https://alfajores-forno.celo-testnet.org"
   },
   "staging": {

--- a/app/packs/src/utils/constants.js
+++ b/app/packs/src/utils/constants.js
@@ -7,8 +7,9 @@ export const THE_GRAPH_ENDPOINTS = {
   production:
     "https://api.studio.thegraph.com/query/10292/talent-tokens/v0.0.5",
   staging:
-    "https://api.studio.thegraph.com/query/10292/talent-protocol/v0.0.19",
-  development: "https://api.studio.thegraph.com/query/8098/mvp/v0.0.23",
+    "https://api.studio.thegraph.com/query/10292/talent-protocol/v0.0.18",
+  development:
+    "https://api.thegraph.com/subgraphs/name/verdefred/celo-alfajores-dev",
 };
 
 export const SUPPORTER_GUIDE =

--- a/app/packs/stylesheets/custom/_cards.scss
+++ b/app/packs/stylesheets/custom/_cards.scss
@@ -360,14 +360,10 @@
   background-color: $gray-900;
 }
 
-.talent-card-body {
+.talent-card-footer {
   height: 75px;
   padding: 16px;
   border-radius: 0px 0px 4px 4px;
-}
-
-.dark-body .talent-card-body {
-  background-color: $surface-02;
 }
 
 .talent-card-details {
@@ -375,10 +371,11 @@
   flex-direction: column;
   height: 280px;
   padding: 16px;
+  border-radius: 4px 4px 0px 0px;
 }
 
 .dark-body .talent-card-details {
-  background-color: $gray-800;
+  background-color: $surface-02;
 }
 
 .talent-card-name {
@@ -394,6 +391,7 @@
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   max-width: 248px;
+  text-align: center;
 }
 
 .talent-card-details-title {
@@ -477,7 +475,7 @@
   max-width: 371px;
   border-radius: 4px;
   background-color: $white;
-  box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.04)
+  box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.04);
 }
 
 .dark-body .nft-card {


### PR DESCRIPTION
## Summary
Discovery page fixes with:
- A Talent shouldn't appear in more than one list in the "frontpage" of the discover section
- Center align occupation line text (instead of left align)
- Change hover background color on dark mode
- Talent card has now only 1 color on dark mode
- Talent cards on discovery page have shadows on light mode

## Notion link
https://www.notion.so/talentprotocol/Discover-page-fixes-07d18bc42fcd4ad4a0aa1843fa5c162b

## How to test?
Check discovery page to see if there's no repeated talent in the different rows (when that's possible)
Check talent card component

## Notes

<!--- Notes you might consider worth adding. -->