### PR TITLE
Add Connected status to mailerlite

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -42,6 +42,7 @@ class API::V1::UsersController < ApplicationController
         @user.update!(wallet_id: params[:wallet_id]&.downcase)
 
         SendCommunityNFTToUser.perform_later(user_id: @user.id)
+        AddUsersToMailerliteJob.perform_later(@user.id)
 
         service = Web3::TransferCelo.new
         service.call(user: @user)

--- a/app/services/mailerlite/sync_subscriber.rb
+++ b/app/services/mailerlite/sync_subscriber.rb
@@ -62,6 +62,8 @@ class Mailerlite::SyncSubscriber
       end
     elsif !user.talent? && user.tokens_purchased?
       "Active"
+    elsif user.wallet_id.present?
+      "Connected"
     else
       "Registered"
     end


### PR DESCRIPTION
## Summary

We want to differentiate between users that just registered and users that have connected their wallets from a marketing perspective