### PR TITLE
Store correct supporter wallet id instead of supporter talent pair

### DIFF
--- a/app/services/talents/refresh_supporters.rb
+++ b/app/services/talents/refresh_supporters.rb
@@ -51,7 +51,7 @@ module Talents
       supporters.each do |supporter|
         talent_supporter = TalentSupporter.find_or_initialize_by(
           talent_contract_id: token.contract_id,
-          supporter_wallet_id: supporter.id
+          supporter_wallet_id: supporter.supporter.id
         )
 
         talent_supporter.update!(

--- a/lib/the_graph/client.rb
+++ b/lib/the_graph/client.rb
@@ -14,6 +14,9 @@ module TheGraph
         ) {
           id
           amount
+          supporter {
+            id
+          }
           talAmount
         }
       }

--- a/spec/services/talents/refresh_supporters_spec.rb
+++ b/spec/services/talents/refresh_supporters_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Talents::RefreshSupporters do
     supporter_counter.to_i.times do
       result << OpenStruct.new(
         id: SecureRandom.hex,
+        supporter: OpenStruct.new(id: SecureRandom.hex),
         amount: "30000000000000000000",
         tal_amount: "150000000000000000000"
       )
@@ -72,12 +73,14 @@ RSpec.describe Talents::RefreshSupporters do
     let(:supporters_data) do
       [
         OpenStruct.new(
-          id: "99asn",
+          id: SecureRandom.hex,
+          supporter: OpenStruct.new(id: "99asn"),
           amount: "60000000000000000000",
           tal_amount: "300000000000000000000"
         ),
         OpenStruct.new(
-          id: "01ksh",
+          id: SecureRandom.hex,
+          supporter: OpenStruct.new(id: "01ksh"),
           amount: "90000000000000000000",
           tal_amount: "450000000000000000000"
         )
@@ -112,6 +115,7 @@ RSpec.describe Talents::RefreshSupporters do
       [
         OpenStruct.new(
           id: SecureRandom.hex,
+          supporter: OpenStruct.new(id: SecureRandom.hex),
           amount: "60000000000000000000",
           tal_amount: "300000000000000000000"
         )


### PR DESCRIPTION
## Summary

### What changed?

Start storing the supporter wallet id instead of supporter talent pair.

### Why it changed?

We need the supporter wallet to know which user is supporting talent.

### How it changed?

Access the correct field in the response data.

## Notion link

https://talentprotocol.notion.site/Add-the-graph-integration-on-backend-f1445d36e2f247abb73fa605908d9389

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->