### PR TITLE
Wait for approval transaction confirmation before allowing token stake

### DIFF
--- a/app/packs/src/onchain/index.js
+++ b/app/packs/src/onchain/index.js
@@ -426,9 +426,11 @@ class OnChain {
       return;
     }
 
-    const result = await this.stabletoken
+    const tx = await this.stabletoken
       .connect(this.signer)
       .approve(this.staking.address, ethers.utils.parseUnits(_amount));
+
+    const result = await tx.wait();
 
     return result;
   }


### PR DESCRIPTION
## Summary

<!--- Summarize the changes made to the platform. (Include screenshoots if applicable) -->
<!--- Try to answer the following three questions: -->

### What changed?

We're now preventing supporters from trying to stake tokens without waiting for the approval transaction.

### Why it changed?

In some scenarios the approval transaction can take some time to finish which leads to an error if the user tries to stake tokens before it is completed.

### How it changed?

We're waiting for the approval transaction to finish.

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->