### PR TITLE
Add tags to talent search

### DIFF
--- a/app/controllers/api/v1/talent_controller.rb
+++ b/app/controllers/api/v1/talent_controller.rb
@@ -3,7 +3,7 @@ class API::V1::TalentController < ApplicationController
     service = Talents::Search.new(filter_params: filter_params.to_h)
     talents = service.call
 
-    render json: TalentBlueprint.render(talents, view: :normal, current_user: current_user), status: :ok
+    render json: TalentBlueprint.render(talents.includes(:user, :token), view: :normal, current_user: current_user), status: :ok
   end
 
   # public /

--- a/app/controllers/api/v1/talent_controller.rb
+++ b/app/controllers/api/v1/talent_controller.rb
@@ -61,7 +61,7 @@ class API::V1::TalentController < ApplicationController
   end
 
   def filter_params
-    params.permit(:name, :status)
+    params.permit(:keyword, :status)
   end
 
   def user_params

--- a/app/controllers/talent_controller.rb
+++ b/app/controllers/talent_controller.rb
@@ -1,6 +1,6 @@
 class TalentController < ApplicationController
   def index
-    service = Talents::Search.new(filter_params: backwards_compatible_params.to_h)
+    service = Talents::Search.new(filter_params: filter_params.to_h)
     talents = service.call
     @talents = talents.includes(:user, :token)
   end
@@ -8,13 +8,6 @@ class TalentController < ApplicationController
   private
 
   def filter_params
-    params.permit(:name, :keyword, :status)
-  end
-
-  def backwards_compatible_params
-    backwards_compatible_params = filter_params
-    backwards_compatible_params[:keyword] = filter_params[:name] if filter_params.key?(:name)
-
-    backwards_compatible_params
+    params.permit(:keyword, :status)
   end
 end

--- a/app/controllers/talent_controller.rb
+++ b/app/controllers/talent_controller.rb
@@ -1,12 +1,20 @@
 class TalentController < ApplicationController
   def index
-    service = Talents::Search.new(filter_params: filter_params.to_h)
-    @talents = service.call
+    service = Talents::Search.new(filter_params: backwards_compatible_params.to_h)
+    talents = service.call
+    @talents = talents.includes(:user, :token)
   end
 
   private
 
   def filter_params
-    params.permit(:name, :status)
+    params.permit(:name, :keyword, :status)
+  end
+
+  def backwards_compatible_params
+    backwards_compatible_params = filter_params
+    backwards_compatible_params[:keyword] = filter_params[:name] if filter_params.key?(:name)
+
+    backwards_compatible_params
   end
 end

--- a/app/models/talent.rb
+++ b/app/models/talent.rb
@@ -27,7 +27,7 @@ class Talent < ApplicationRecord
   has_many :perks
   has_many :milestones
 
-  scope :base, -> { where(public: true).includes([:user, :token]) }
+  scope :base, -> { where(public: true) }
   scope :active, -> { joins(:token).where.not(tokens: {contract_id: nil}) }
   scope :upcoming, -> { joins(:token).where(tokens: {contract_id: nil}) }
 

--- a/app/packs/entrypoints/application.js
+++ b/app/packs/entrypoints/application.js
@@ -14,7 +14,7 @@ import ReactOnRails from "react-on-rails";
 import TalentShow from "src/components/talent/TalentShow";
 import MessageUserList from "src/components/chat/MessageUserList";
 import Chat from "src/components/chat/Chat";
-import TalentNameSearch from "src/components/talent/TalentNameSearch";
+import TalentKeywordSearch from "src/components/talent/TalentKeywordSearch";
 import Web3ModalConnect from "src/components/login/Web3ModalConnect";
 import UpcomingTalents from "src/components/talent/UpcomingTalents";
 import Notifications from "src/components/notifications";
@@ -47,7 +47,7 @@ ReactOnRails.register({
   MessageUserList,
   Chat,
   RegistrationFlow,
-  TalentNameSearch,
+  TalentKeywordSearch,
   Login,
   Web3ModalConnect,
   TopBar,

--- a/app/packs/src/components/supporters/show/SupportingOptions.jsx
+++ b/app/packs/src/components/supporters/show/SupportingOptions.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 
 import Button from "src/components/design_system/button";
 import TabButton from "src/components/design_system/tab/TabButton.jsx";
-import TalentNameSearch from "src/components/talent/TalentNameSearch";
+import TalentKeywordSearch from "src/components/talent/TalentKeywordSearch";
 import { Grid, List } from "src/components/icons";
 import { useWindowDimensionsHook } from "src/utils/window";
 
@@ -46,7 +46,7 @@ const SupportingOptions = ({
         />
       )}
       <div className={cx("d-flex", mobile && "mt-3")}>
-        <TalentNameSearch
+        <TalentKeywordSearch
           className="ml-2"
           name={name}
           setName={setName}

--- a/app/packs/src/components/talent/TalentKeywordSearch.jsx
+++ b/app/packs/src/components/talent/TalentKeywordSearch.jsx
@@ -2,13 +2,13 @@ import React from "react";
 import TextInput from "src/components/design_system/fields/textinput";
 import { Search } from "src/components/icons";
 
-const TalentNameSearch = ({ name, setName, filter, className }) => {
+const TalentKeywordSearch = ({ keyword, setKeyword, filter, className }) => {
   return (
-    <form onSubmit={(e) => filter(e, "name", name)} className={className}>
+    <form onSubmit={(e) => filter(e, "keyword", keyword)} className={className}>
       <div className="position-relative">
         <TextInput
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
           placeholder="Search"
           inputClassName="pl-5"
           className="w-100"
@@ -22,4 +22,4 @@ const TalentNameSearch = ({ name, setName, filter, className }) => {
   );
 };
 
-export default TalentNameSearch;
+export default TalentKeywordSearch;

--- a/app/packs/src/components/talent/TalentOptions.jsx
+++ b/app/packs/src/components/talent/TalentOptions.jsx
@@ -3,7 +3,7 @@ import { get } from "src/utils/requests";
 
 import Button from "src/components/design_system/button";
 import TabButton from "src/components/design_system/tab/TabButton.jsx";
-import TalentNameSearch from "./TalentNameSearch";
+import TalentKeywordSearch from "./TalentKeywordSearch";
 import TalentFilters from "./TalentFilters";
 import { Grid, List } from "src/components/icons";
 import { useWindowDimensionsHook } from "src/utils/window";
@@ -21,7 +21,10 @@ const TalentOptions = ({
 }) => {
   const { mobile } = useWindowDimensionsHook();
   const url = new URL(document.location);
-  const [name, setName] = useState(url.searchParams.get("name") || "");
+  // Kept name support for backwards compatibility
+  const [keyword, setKeyword] = useState(
+    url.searchParams.get("name") || url.searchParams.get("keyword") || ""
+  );
   const [status, setStatus] = useState(url.searchParams.get("status") || "All");
 
   const filter = (e, filterType, option) => {
@@ -65,7 +68,11 @@ const TalentOptions = ({
         onClick={(tab) => changeTab(tab)}
       />
       <div className={cx("d-flex", mobile && "mt-3")}>
-        <TalentNameSearch name={name} setName={setName} filter={filter} />
+        <TalentKeywordSearch
+          keyword={keyword}
+          setKeyword={setKeyword}
+          filter={filter}
+        />
         <div className="ml-2">
           <TalentFilters
             status={status}

--- a/app/packs/src/components/talent/TalentOptions.jsx
+++ b/app/packs/src/components/talent/TalentOptions.jsx
@@ -21,10 +21,7 @@ const TalentOptions = ({
 }) => {
   const { mobile } = useWindowDimensionsHook();
   const url = new URL(document.location);
-  // Kept name support for backwards compatibility
-  const [keyword, setKeyword] = useState(
-    url.searchParams.get("name") || url.searchParams.get("keyword") || ""
-  );
+  const [keyword, setKeyword] = useState(url.searchParams.get("keyword") || "");
   const [status, setStatus] = useState(url.searchParams.get("status") || "All");
 
   const filter = (e, filterType, option) => {

--- a/app/packs/src/components/talent/UserTags.jsx
+++ b/app/packs/src/components/talent/UserTags.jsx
@@ -15,7 +15,9 @@ const UserTags = ({ tags, talent_id, className, mode }) => {
       >
         {validTags.map((tag) => (
           <Tag mode={mode} className="mr-2 mt-2" key={`${talent_id}_${tag}`}>
-            <P2 mode={mode} text={tag} bold />
+            <a href={`/talent?keyword=${tag}`} className="text-decoration-none">
+              <P2 mode={mode} text={tag} bold role="button" />
+            </a>
           </Tag>
         ))}
       </div>

--- a/lib/tasks/seeds/talent.rake
+++ b/lib/tasks/seeds/talent.rake
@@ -1,0 +1,52 @@
+if Rails.env.development?
+  namespace :talent do
+    task add_more_talent_profiles: :environment do
+      puts "Setting up tags.."
+
+      tags = Array.new(10) do |i|
+        Tag.create!(description: Faker::Job.field)
+      end
+
+      20.times do |index|
+        name = Faker::Name.name
+        username = name.gsub(/[^a-z0-9]/, "").downcase
+        email = Faker::Internet.email
+
+        puts "Creating talent with #{username} - #{email}"
+
+        talent_user = User.create!(
+          username: username,
+          display_name: name,
+          email: email,
+          password: "password",
+          email_confirmed_at: Time.zone.now
+        )
+
+        talent_user.tags << tags.sample
+
+        talent = Talent.create!(
+          ito_date: Time.current - 1.week,
+          activity_count: index,
+          user: talent_user,
+          public: true
+        )
+
+        Token.create!(
+          ticker: username.upcase[0, 5],
+          talent: talent
+        )
+
+        puts "Setting up Career Goals.."
+        CareerGoal.create(
+          target_date: Date.today + 1.year,
+          description: Faker::Company.catch_phrase,
+          talent: talent
+        )
+
+        Feed.create(user: talent_user)
+        post = Post.create(user: talent_user, text: Faker::Lorem.paragraph)
+        talent_user.feed.posts << post
+      end
+    end
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :tag do
+  end
+end

--- a/spec/factories/talents.rb
+++ b/spec/factories/talents.rb
@@ -1,4 +1,9 @@
 FactoryBot.define do
   factory :talent do
+    public { true }
+
+    trait :with_token do
+      association :token
+    end
   end
 end

--- a/spec/services/talents/search_spec.rb
+++ b/spec/services/talents/search_spec.rb
@@ -61,14 +61,18 @@ RSpec.describe Talents::Search do
       end
 
       before do
-        tag = create :tag, description: "web3"
+        tag_1 = create :tag, description: "web3"
+        tag_2 = create :tag, description: "design"
+        tag_3 = create :tag, description: "development"
 
-        user_1.tags << tag
-        user_3.tags << tag
+        user_1.tags << [tag_1, tag_3]
+        user_2.tags << [tag_2]
+        user_3.tags << [tag_1, tag_2]
+        user_4.tags << [tag_3]
       end
 
       it "returns all talent users with tags matching the passed keyword" do
-        expect(search_talents).to match_array([talent_1, talent_3])
+        expect(search_talents).to eq([talent_1, talent_3])
       end
     end
   end

--- a/spec/services/talents/search_spec.rb
+++ b/spec/services/talents/search_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe Talents::Search do
+  subject(:search_talents) { described_class.new(filter_params: filter_params, sort_params: sort_params).call }
+
+  let(:sort_params) { {} }
+
+  let!(:user_1) { create :user, talent: talent_1, username: "jonas" }
+  let(:talent_1) { create :talent, :with_token, public: true }
+  let!(:user_2) { create :user, talent: talent_2, display_name: "Alexander" }
+  let(:talent_2) { create :talent, :with_token, public: true }
+  let!(:user_3) { create :user, talent: talent_3, username: "jonathan" }
+  let(:talent_3) { create :talent, :with_token, public: true }
+  let!(:user_4) { create :user, talent: talent_4, display_name: "Alex" }
+  let(:talent_4) { create :talent, :with_token, public: true }
+
+  let!(:private_user) { create :user, talent: private_talent, display_name: "Alexandrina" }
+  let(:private_talent) { create :talent, :with_token, public: false }
+
+  let!(:user_without_token) { create :user, talent: talent_without_token, username: "jona" }
+  let(:talent_without_token) { create :talent, public: true }
+
+  context "when filter params are empty" do
+    let(:filter_params) { {} }
+
+    it "returns all talent users" do
+      expect(search_talents).to match_array([talent_1, talent_2, talent_3, talent_4])
+    end
+  end
+
+  context "when the keyword filter is passed" do
+    context "when it matches the user username" do
+      let(:filter_params) do
+        {
+          keyword: "jona"
+        }
+      end
+
+      it "returns all talent users with username matching the passed keyword" do
+        expect(search_talents).to match_array([talent_1, talent_3])
+      end
+    end
+
+    context "when it matches the user display_name" do
+      let(:filter_params) do
+        {
+          keyword: "ale"
+        }
+      end
+
+      it "returns all talent users with display_name matching the passed keyword" do
+        expect(search_talents).to match_array([talent_2, talent_4])
+      end
+    end
+
+    context "when it matches the user tags" do
+      let(:filter_params) do
+        {
+          keyword: "web3"
+        }
+      end
+
+      before do
+        tag = create :tag, description: "web3"
+
+        user_1.tags << tag
+        user_3.tags << tag
+      end
+
+      it "returns all talent users with tags matching the passed keyword" do
+        expect(search_talents).to match_array([talent_1, talent_3])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

<!--- Summarize the changes made to the platform. (Include screenshoots if applicable) -->
<!--- Try to answer the following three questions: -->

### What changed?

We're now allowing search by tags.

### Why it changed?

Supporters might want to invest in a particular subset of talented people and having a way to filter it will help.

### How it changed?

We've included tags in the talent search query and added a link to the talent search when a tag is clicked.

## Notion link

https://www.notion.so/talentprotocol/Improve-Search-fc97a187f0d146d3b4d1f0b5ef48dfd7

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->