### PR TITLE
Add rack app with health endpoint

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,11 @@
 # This file is used by Rack-based servers to start the application.
 
 require_relative "config/environment"
+require_relative "lib/rack/health_check"
+
+map "/health" do
+  run Rack::HealthCheck.new
+end
 
 run Rails.application
 Rails.application.load_server

--- a/lib/rack/health_check.rb
+++ b/lib/rack/health_check.rb
@@ -1,0 +1,50 @@
+require "the_graph/client"
+require "json"
+
+module Rack
+  class HealthCheck
+    def call(env)
+      status = {
+        redis: {
+          connected: redis_connected
+        },
+        postgres: {
+          connected: postgres_connected
+        },
+        the_graph: {
+          connected: the_graph_connected
+        }
+      }
+
+      [200, {}, [JSON.generate(status)]]
+    end
+
+    protected
+
+    def redis_connected
+      redis.ping == "PONG"
+    rescue
+      false
+    end
+
+    def redis
+      Redis.new(url: ENV["REDIS_URL"])
+    end
+
+    def postgres_connected
+      return true if ApplicationRecord.connected?
+
+      ApplicationRecord.establish_connection
+      ApplicationRecord.connection
+      ApplicationRecord.connected?
+    rescue
+      false
+    end
+
+    def the_graph_connected
+      !!TheGraphAPI::Client.query(TheGraph::HEALTH_CHECK_QUERY, variables: {})
+    rescue
+      false
+    end
+  end
+end

--- a/lib/the_graph/client.rb
+++ b/lib/the_graph/client.rb
@@ -23,6 +23,14 @@ module TheGraph
     }
   GRAPHQL
 
+  HEALTH_CHECK_QUERY = ::TheGraphAPI::Client.parse <<-'GRAPHQL'
+    query {
+      talentTokens(first: 1) {
+        id
+      }
+    }
+  GRAPHQL
+
   class Client
     class Error < StandardError; end
 


### PR DESCRIPTION
## Summary

This PR introduces a health endpoint that validates that the app and some services are up and running. We have introduced this to integrate with an uptime service.


## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
