### PR TITLE
Talent quest goes to form for supporters

### DIFF
--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -6,6 +6,9 @@ class UserBlueprint < Blueprinter::Base
     field :name do |user, _options|
       user.display_name || user.username
     end
+    field :is_talent do |user, _options|
+      user.talent.present?
+    end
   end
 
   view :extended do

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,7 +21,7 @@ class UsersController < ApplicationController
     talent = @user.talent
     investor = @user.investor
 
-    API::CreateProfilePageVisitor.new.call(ip: request.remote_ip, user: @user)
+    CreateProfilePageVisitorJob.perform_later(ip: request.remote_ip, user_id: @user.id)
 
     if talent
       @talent = TalentBlueprint.render_as_json(

--- a/app/jobs/create_profile_page_visitor_job.rb
+++ b/app/jobs/create_profile_page_visitor_job.rb
@@ -1,0 +1,9 @@
+class CreateProfilePageVisitorJob < ApplicationJob
+  queue_as :default
+
+  def perform(ip:, user_id:)
+    user = User.find(user_id)
+
+    API::CreateProfilePageVisitor.new.call(ip: ip, user: user)
+  end
+end

--- a/app/packs/src/components/design_system/cards/QuestCard.jsx
+++ b/app/packs/src/components/design_system/cards/QuestCard.jsx
@@ -5,6 +5,7 @@ import ProgressCircle from "src/components/design_system/progress_circle";
 import Button from "src/components/design_system/button";
 import Divider from "src/components/design_system/other/Divider";
 import { questDescription, taskReward } from "src/utils/questsHelpers";
+import { TALENT_TOKEN_APPLICATION_FORM } from "src/utils/constants";
 
 import cx from "classnames";
 
@@ -17,9 +18,10 @@ const QuestCard = ({
   completedTasks,
   tasksType,
   status,
-  onClick,
+  user,
 }) => {
   const progress = completedTasks / allTasks || 0;
+  const supporterOnTalentQuest = type === "Quests::Talent" && !user.is_talent;
 
   const buttonText = useMemo(() => {
     switch (status) {
@@ -54,6 +56,14 @@ const QuestCard = ({
   const completed = status === "done";
 
   const rewards = tasksType.map((type) => taskReward(type, completed));
+
+  const onClickButton = useMemo(() => {
+    if (supporterOnTalentQuest) {
+      return TALENT_TOKEN_APPLICATION_FORM;
+    }
+
+    return `/quests/${id}`;
+  }, [supporterOnTalentQuest]);
 
   return (
     <div className={cx("highlights-card", completed && "disabled")}>
@@ -102,14 +112,20 @@ const QuestCard = ({
             </div>
           ))}
         </div>
-        <Button
-          className="w-100"
-          disabled={completed}
-          size="extra-big"
-          type={buttonType}
-          text={buttonText}
-          onClick={() => onClick(id)}
-        />
+        <a
+          className="button-link"
+          href={onClickButton}
+          target={supporterOnTalentQuest ? "_blank" : "_self"}
+        >
+          <Button
+            className="w-100"
+            disabled={completed}
+            size="extra-big"
+            type={buttonType}
+            text={buttonText}
+            onClick={() => null}
+          />
+        </a>
       </div>
     </div>
   );

--- a/app/packs/src/components/rewards/quests/index.jsx
+++ b/app/packs/src/components/rewards/quests/index.jsx
@@ -55,7 +55,7 @@ const Quests = ({ quests, questId, setQuestId }) => {
                   }
                   tasksType={quest.tasks.map((task) => task.type)}
                   status={quest.status}
-                  onClick={() => (window.location.href = `/quests/${quest.id}`)}
+                  user={quest.user}
                 />
               </div>
             ))}

--- a/app/services/api/create_profile_page_visitor.rb
+++ b/app/services/api/create_profile_page_visitor.rb
@@ -1,9 +1,16 @@
 module API
   class CreateProfilePageVisitor
-    def call(ip:, user:)
-      profile_page_visitor = ProfilePageVisitor.find_or_create_by!(user: user, ip: ip)
-      profile_page_visitor.update(last_visited_at: Time.current)
+    MAX_RETRIES = 5
 
+    def call(ip:, user:)
+      count = 0
+      begin
+        profile_page_visitor = ProfilePageVisitor.find_or_create_by!(user: user, ip: ip)
+        profile_page_visitor.update(last_visited_at: Time.current)
+      rescue ActiveRecord::RecordInvalid
+        count += 1
+        retry if count <= MAX_RETRIES
+      end
       if ProfilePageVisitor.where(user: user).count >= (ENV["VISITORS_COUNT"].to_i || 10)
         UpdateTasksJob.perform_later(type: "Tasks::ShareProfile", user_id: user.id)
       end


### PR DESCRIPTION
## Summary
We came to the conclusion that it didn't make sense for a supporter to make the tasks on the Talent quest, so now the user is redirected to our form to apply for launching a token

This PR also fixes a concurrency issue with the CreateProfilePageVisitor

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
