### PR TITLE
Resend notifications when the last notification sent was more than a week ago

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -14,4 +14,8 @@ class Notification < ApplicationRecord
   def mark_as_emailed
     update_column(:emailed_at, Time.current)
   end
+
+  def unread_for_more_than_a_week?
+    unread? && created_at <= (Time.current - 7.days)
+  end
 end

--- a/spec/integration/notifications/message_notifications_delivery_spec.rb
+++ b/spec/integration/notifications/message_notifications_delivery_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe "Message notifications delivery" do
+  let(:sender) { create :user }
+  let(:receiver) { create :user }
+
+  subject(:send_message) do
+    Messages::Send.new.call(
+      sender: sender,
+      receiver: receiver,
+      message: "Hello!"
+    )
+  end
+
+  context "when the receiver has no unread messages" do
+    it "creates a new notification" do
+      expect { send_message }.to change(Notification, :count).from(0).to(1)
+    end
+
+    it "enqueues a job to send the notification by email" do
+      expect { send_message }.to have_enqueued_job(Noticed::DeliveryMethods::Email)
+    end
+  end
+
+  context "when the receiver has unread messages from this week" do
+    before do
+      create(
+        :notification,
+        type: "MessageReceivedNotification",
+        read_at: nil,
+        recipient: receiver,
+        created_at: Date.yesterday
+      )
+    end
+
+    it "does not create a new notification" do
+      expect { send_message }.not_to change(Notification, :count)
+    end
+  end
+
+  context "when the receiver has unread messages created more than week ago" do
+    let!(:notification) do
+      create(
+        :notification,
+        type: "MessageReceivedNotification",
+        read_at: nil,
+        recipient: receiver,
+        created_at: Date.today - 10.days
+      )
+    end
+
+    it "creates a new notification" do
+      expect { send_message }.to change(Notification, :count).from(1).to(2)
+    end
+
+    it "marks the old notification as read" do
+      send_message
+
+      expect(notification.reload.read?).to eq(true)
+    end
+
+    it "enqueues a job to send the notification by email" do
+      expect { send_message }.to have_enqueued_job(Noticed::DeliveryMethods::Email)
+    end
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe Notification, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:recipient) }
+  end
+
+  describe "#unread_for_more_than_a_week?" do
+    let(:notification) { create :notification, created_at: created_at, recipient: create(:user) }
+    let(:created_at) { Time.current }
+
+    context "when the notification was created today" do
+      let(:created_at) { Time.current }
+
+      it "returns false" do
+        expect(notification.unread_for_more_than_a_week?).to eq false
+      end
+    end
+
+    context "when the notification was created 6 days ago" do
+      let(:created_at) { Time.current - 6.days }
+
+      it "returns false" do
+        expect(notification.unread_for_more_than_a_week?).to eq false
+      end
+    end
+
+    context "when the notification was created 7 days ago" do
+      let(:created_at) { Time.current - 7.days }
+
+      it "returns true" do
+        expect(notification.unread_for_more_than_a_week?).to eq true
+      end
+    end
+
+    context "when the notification was created 30 days ago" do
+      let(:created_at) { Time.current - 30.days }
+
+      it "returns true" do
+        expect(notification.unread_for_more_than_a_week?).to eq true
+      end
+    end
+  end
+end

--- a/spec/services/talents/search_spec.rb
+++ b/spec/services/talents/search_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Talents::Search do
         user_4.tags << [tag_3]
       end
 
-      fit "returns all talent users with tags matching the passed keyword" do
+      it "returns all talent users with tags matching the passed keyword" do
         expect(search_talents).to match_array([talent_1, talent_3])
       end
     end


### PR DESCRIPTION
## Summary

We are not sending new email notifications if the user already has an unread notification. From now on we will trigger a new email if the last unread notification was sent longer than a week ago.

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
