### PR TITLE
Include pictures on rewards table for the race tab

### DIFF
--- a/app/blueprints/reward_blueprint.rb
+++ b/app/blueprints/reward_blueprint.rb
@@ -4,6 +4,6 @@ class RewardBlueprint < Blueprinter::Base
   view :normal do
     fields :amount, :created_at
 
-    association :user, blueprint: UserBlueprint, view: :normal
+    association :user, blueprint: UserBlueprint, view: :with_pictures
   end
 end

--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -15,4 +15,11 @@ class UserBlueprint < Blueprinter::Base
     include_view :normal
     fields :email, :wallet_id
   end
+
+  view :with_pictures do
+    include_view :normal
+    field :profilePictureUrl do |user, _options|
+      user.talent&.profile_picture_url || user.investor.profile_picture_url
+    end
+  end
 end


### PR DESCRIPTION
## Summary

The normal user blueprint does not include profile pictures and therefore we are not able to see the profiles pictures. Creating a new view that includes the profile pictures for both talent and supporters and using that view on the rewards blueprint will fix this.