### PR TITLE
Display message input below last message and not in the bottom

### DIFF
--- a/app/packs/src/components/chat/MessageExchange.jsx
+++ b/app/packs/src/components/chat/MessageExchange.jsx
@@ -117,7 +117,7 @@ const MessageExchange = (props) => {
   };
 
   return (
-    <div className="h-100 d-flex flex-column">
+    <div className="d-flex flex-column">
       {props.smallScreen && (
         <>
           <div className="d-flex flex-row align-items-center w-100 py-2">


### PR DESCRIPTION
## Summary

This PR fixes the spacing between messages and the input to type a message.

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
