### PR TITLE
Add 30 day Market Cap Variance to talents

### DIFF
--- a/app/packs/src/components/talent/TalentPage.jsx
+++ b/app/packs/src/components/talent/TalentPage.jsx
@@ -165,7 +165,8 @@ const TalentPage = ({ talents }) => {
             tokenDayData || [],
             deployDateUTC,
             startDate,
-            endDate
+            endDate,
+            totalSupply
           ),
         };
       }

--- a/app/packs/src/components/talent/TalentPage.jsx
+++ b/app/packs/src/components/talent/TalentPage.jsx
@@ -144,7 +144,7 @@ const TalentPage = ({ talents }) => {
         progress: getProgress(totalSupply, maxSupply),
         marketCap: getMarketCap(totalSupply),
         supporterCounter: getSupporterCount(supporterCounter),
-        marketCapVariance: getMarketCapVariance(tokenDayData),
+        marketCapVariance: getMarketCapVariance(tokenDayData || []),
       })
     );
 

--- a/app/packs/src/components/talent/TalentPage.jsx
+++ b/app/packs/src/components/talent/TalentPage.jsx
@@ -13,6 +13,7 @@ import {
   getSupporterCount,
   getMarketCap,
   getProgress,
+  getMarketCapVariance,
 } from "src/utils/viewHelpers";
 import { compareStrings, compareNumbers } from "src/utils/compareHelpers";
 import { post, destroy } from "src/utils/requests";
@@ -130,25 +131,44 @@ const TalentPage = ({ talents }) => {
     }
 
     const newTalents = data.talentTokens.map(
-      ({ id, totalSupply, maxSupply, supporterCounter, ...rest }) => ({
+      ({
+        id,
+        totalSupply,
+        maxSupply,
+        supporterCounter,
+        tokenDayData,
+        ...rest
+      }) => ({
         ...rest,
         token: { contractId: id },
         progress: getProgress(totalSupply, maxSupply),
         marketCap: getMarketCap(totalSupply),
         supporterCounter: getSupporterCount(supporterCounter),
+        marketCapVariance: getMarketCapVariance(tokenDayData),
       })
     );
 
     setLocalTalents((prev) =>
       Object.values(
         [...prev, ...newTalents].reduce(
-          (result, { id, token, marketCap, supporterCounter, ...rest }) => {
+          (
+            result,
+            {
+              id,
+              token,
+              marketCap,
+              supporterCounter,
+              marketCapVariance,
+              ...rest
+            }
+          ) => {
             result[token.contractId || id] = {
               ...(result[token.contractId || id] || {}),
               id: result[token.contractId || id]?.id || id,
               token: { ...result[token.contractId]?.token, ...token },
               marketCap: marketCap || "-1",
               supporterCounter: supporterCounter || "-1",
+              marketCapVariance: marketCapVariance || "-1",
               ...rest,
             };
 

--- a/app/packs/src/components/talent/TalentTableListMode.jsx
+++ b/app/packs/src/components/talent/TalentTableListMode.jsx
@@ -155,6 +155,8 @@ const TalentTableListMode = ({
         return talent.occupation;
       case "Market Cap":
         return contractId ? `$${talent.marketCap}` : "-";
+      case "Market Cap Variance":
+        return contractId ? `$${talent.marketCapVariance}` : "-";
       case "Alphabetical Order":
         return talent.occupation;
       case "First Buy":
@@ -278,6 +280,16 @@ const TalentTableListMode = ({
             className="cursor-pointer"
           />
         </Table.Th>
+        <Table.Th className="col-2 px-0">
+          <Caption
+            onClick={() => onOptionClick("Market Cap Variance")}
+            bold
+            text={`30 DAY MARKET CAP VARIANCE${sortIcon(
+              "Market Cap Variance"
+            )}`}
+            className="cursor-pointer"
+          />
+        </Table.Th>
         {showFirstBoughtField && (
           <Table.Th>
             <Caption
@@ -376,6 +388,23 @@ const TalentTableListMode = ({
                   aria-valuemax="100"
                 ></div>
               </div>
+            </Table.Td>
+            <Table.Td
+              className={cx(
+                "pr-3",
+                talent.token.contractId ? "" : "d-flex justify-content-center"
+              )}
+              onClick={() =>
+                (window.location.href = `/u/${talent.user.username}`)
+              }
+            >
+              <P2
+                text={
+                  talent.token.contractId
+                    ? `${currency(talent.marketCapVariance).format()}`
+                    : "-"
+                }
+              />
             </Table.Td>
             {showFirstBoughtField && (
               <Table.Td>

--- a/app/packs/src/utils/thegraph.js
+++ b/app/packs/src/utils/thegraph.js
@@ -35,6 +35,11 @@ const GET_TALENT_PORTFOLIO = gql`
       maxSupply
       marketCap
       name
+      tokenDayData(orderBy: date, orderDirection: desc, first: 30) {
+        id
+        date
+        dailySupply
+      }
     }
   }
 `;

--- a/app/packs/src/utils/thegraph.js
+++ b/app/packs/src/utils/thegraph.js
@@ -27,7 +27,7 @@ const client = (env) => {
 export const PAGE_SIZE = 30;
 
 const GET_TALENT_PORTFOLIO = gql`
-  query GetTalentList($ids: [String!]) {
+  query GetTalentList($ids: [String!], $startDate: Int!, $endDate: Int!) {
     talentTokens(first: 500, where: { id_in: $ids }) {
       id
       supporterCounter
@@ -35,7 +35,10 @@ const GET_TALENT_PORTFOLIO = gql`
       maxSupply
       marketCap
       name
-      tokenDayData(orderBy: date, orderDirection: desc, first: 30) {
+      tokenDayData(
+        where: { date_gte: $startDate, date_lt: $endDate }
+        orderBy: date
+      ) {
         id
         date
         dailySupply

--- a/app/packs/src/utils/viewHelpers.js
+++ b/app/packs/src/utils/viewHelpers.js
@@ -36,3 +36,20 @@ export const getProgress = (totalSupply, maxSupply) => {
     return value;
   }
 };
+
+export const getMarketCapVariance = (tokenDayData) => {
+  const supplies = tokenDayData.map((data) =>
+    parseFloat(ethers.utils.formatUnits(data.dailySupply))
+  );
+
+  const totalSupply = supplies.reduce((prev, current) => prev + current, 0);
+  const mean = totalSupply / supplies.length;
+
+  const sumForVariance = supplies.reduce(
+    (prev, current) => prev + Math.pow(current - mean, 2),
+    0
+  );
+  const variance = sumForVariance / supplies.length;
+  const marketCapVariance = parseAndCommify(variance * 0.1);
+  return marketCapVariance;
+};

--- a/app/packs/src/utils/viewHelpers.js
+++ b/app/packs/src/utils/viewHelpers.js
@@ -41,7 +41,8 @@ export const getMarketCapVariance = (
   tokenDayData,
   deployDate,
   startDate,
-  endDate
+  endDate,
+  totalSupply
 ) => {
   const supplies = [];
   const dayData = {};
@@ -56,13 +57,15 @@ export const getMarketCapVariance = (
       supplies.push(0);
     } else if (dayData[date]) {
       supplies.push(dayData[date]);
+    } else if (i == 0) {
+      supplies.push(parseFloat(ethers.utils.formatUnits(totalSupply)));
     } else {
       supplies.push(supplies[i - 1]);
     }
     i++;
   }
-  const totalSupply = supplies.reduce((prev, current) => prev + current, 0);
-  const mean = totalSupply / supplies.length;
+  const totalDailySupply = supplies.reduce((prev, current) => prev + current, 0);
+  const mean = totalDailySupply / supplies.length;
 
   const sumForVariance = supplies.reduce(
     (prev, current) => prev + Math.pow(current - mean, 2),

--- a/app/packs/src/utils/viewHelpers.js
+++ b/app/packs/src/utils/viewHelpers.js
@@ -48,6 +48,10 @@ export const getMarketCapVariance = (
   const dayData = {};
   const dayInSeconds = 86400;
 
+  if (tokenDayData.length == 0) {
+    return '0';
+  }
+
   tokenDayData.forEach((data) => {
     dayData[data.date] = parseFloat(ethers.utils.formatUnits(data.dailySupply));
   });

--- a/app/packs/src/utils/viewHelpers.js
+++ b/app/packs/src/utils/viewHelpers.js
@@ -37,11 +37,30 @@ export const getProgress = (totalSupply, maxSupply) => {
   }
 };
 
-export const getMarketCapVariance = (tokenDayData) => {
-  const supplies = tokenDayData.map((data) =>
-    parseFloat(ethers.utils.formatUnits(data.dailySupply))
-  );
+export const getMarketCapVariance = (
+  tokenDayData,
+  deployDate,
+  startDate,
+  endDate
+) => {
+  const supplies = [];
+  const dayData = {};
+  const dayInSeconds = 86400;
 
+  tokenDayData.forEach((data) => {
+    dayData[data.date] = parseFloat(ethers.utils.formatUnits(data.dailySupply));
+  });
+
+  for (let date = startDate, i = 0; date < endDate; date += dayInSeconds) {
+    if (date < deployDate) {
+      supplies.push(0);
+    } else if (dayData[date]) {
+      supplies.push(dayData[date]);
+    } else {
+      supplies.push(supplies[i - 1]);
+    }
+    i++;
+  }
   const totalSupply = supplies.reduce((prev, current) => prev + current, 0);
   const mean = totalSupply / supplies.length;
 

--- a/app/views/talent/index.html.erb
+++ b/app/views/talent/index.html.erb
@@ -11,7 +11,8 @@
               headline: talent.headline,
               token: {
                 ticker: talent.token.ticker,
-                contractId: talent.token.contract_id
+                contractId: talent.token.contract_id,
+                deployedAt: talent.token.deployed_at,
               },
               user: {
                 username: talent.user.username,


### PR DESCRIPTION
## Summary

This PR adds the ability to track the total supply of talent tokens over time to help evaluate the Talent Token’s evolution over time.
It stores the total supply of the token for each day in the subgraph implementation and uses the stored values for the last 30 days to calculate the 30-day Market Cap Variance of talent tokens.
The 30-day Market Cap Variance is displayed in the talents table. 

## Notion link

https://talentprotocol.notion.site/Track-Token-Total-Supply-over-times-7dda974032c8482d9e607ec81158ea15