### PR TITLE
Redirect message links to correct path after click

### DIFF
--- a/app/packs/src/components/chat/Message.jsx
+++ b/app/packs/src/components/chat/Message.jsx
@@ -49,7 +49,7 @@ const MessageLinkified = (props) => {
     }
     e.preventDefault();
     setShowPishingModal(true);
-    setUrl(e.target.origin);
+    setUrl(e.target.href);
   };
 
   return (


### PR DESCRIPTION
## Summary

This PR fixes the url redirection when someone clicks on a link sent via messages.

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
