### PR TITLE
Add discovery row page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ yarn-debug.log*
 
 # Ignore minIO data folder
 /data
+
+/vendor/ruby

--- a/Gemfile
+++ b/Gemfile
@@ -107,6 +107,7 @@ end
 
 group :test do
   gem "capybara", ">= 3.26"
+  gem "rails-controller-testing"
   gem "rspec-rails", "~> 5.0.1"
   gem "selenium-webdriver"
   gem "shoulda-matchers", "~> 4.5.1"

--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,9 @@ gem "noticed", "~> 1.5"
 # Perfomance monitoring
 gem "newrelic_rpm"
 
+# Slug generation
+gem "friendly_id", "~> 5.4.0"
+
 group :development, :test do
   gem "awesome_print"
   gem "bundler-audit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,6 +322,10 @@ GEM
       bundler (>= 1.15.0)
       railties (= 6.1.4.6)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -518,6 +522,7 @@ DEPENDENCIES
   rack-attack
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4, >= 6.1.4.6)
+  rails-controller-testing
   react_on_rails (= 12.2.0)
   redis (~> 4.3)
   rmagick

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,8 @@ GEM
       ffi (>= 1.0.0)
       rake
     foreman (0.87.2)
+    friendly_id (5.4.2)
+      activerecord (>= 4.0.0)
     fugit (1.5.2)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.4)
@@ -497,6 +499,7 @@ DEPENDENCIES
   faker
   faraday
   foreman
+  friendly_id (~> 5.4.0)
   graphql-client
   image_processing (~> 1.12)
   jbuilder (~> 2.7)

--- a/app/blueprints/discovery_row_blueprint.rb
+++ b/app/blueprints/discovery_row_blueprint.rb
@@ -1,7 +1,13 @@
 class DiscoveryRowBlueprint < Blueprinter::Base
-  fields :id, :badge, :badge_link, :slug, :title, :description, :logo_url, :talents_count
+  fields :id, :slug
 
   view :normal do
+    fields :badge, :badge_link, :title, :description, :logo_url, :talents_count
+  end
+
+  view :with_talents do
+    include_view :normal
+
     association :talents, blueprint: TalentBlueprint, view: :normal
   end
 end

--- a/app/blueprints/discovery_row_blueprint.rb
+++ b/app/blueprints/discovery_row_blueprint.rb
@@ -1,5 +1,5 @@
 class DiscoveryRowBlueprint < Blueprinter::Base
-  fields :id, :title, :badge, :badge_link
+  fields :id, :badge, :badge_link, :slug, :title
 
   view :normal do
     association :talents, blueprint: TalentBlueprint, view: :normal

--- a/app/blueprints/discovery_row_blueprint.rb
+++ b/app/blueprints/discovery_row_blueprint.rb
@@ -3,6 +3,8 @@ class DiscoveryRowBlueprint < Blueprinter::Base
 
   view :normal do
     fields :badge, :badge_link, :title, :description, :logo_url, :talents_count
+
+    association :tags, blueprint: TagBlueprint
   end
 
   view :with_talents do

--- a/app/blueprints/discovery_row_blueprint.rb
+++ b/app/blueprints/discovery_row_blueprint.rb
@@ -1,5 +1,5 @@
 class DiscoveryRowBlueprint < Blueprinter::Base
-  fields :id, :badge, :badge_link, :slug, :title
+  fields :id, :badge, :badge_link, :slug, :title, :description, :logo_url, :talents_count
 
   view :normal do
     association :talents, blueprint: TalentBlueprint, view: :normal

--- a/app/blueprints/discovery_row_blueprint.rb
+++ b/app/blueprints/discovery_row_blueprint.rb
@@ -4,7 +4,7 @@ class DiscoveryRowBlueprint < Blueprinter::Base
   view :normal do
     fields :badge, :badge_link, :title, :description, :logo_url, :talents_count
 
-    association :tags, blueprint: TagBlueprint
+    association :visible_tags, blueprint: TagBlueprint
   end
 
   view :with_talents do

--- a/app/blueprints/talent_blueprint.rb
+++ b/app/blueprints/talent_blueprint.rb
@@ -7,7 +7,7 @@ class TalentBlueprint < Blueprinter::Base
     association :user, blueprint: UserBlueprint, view: :normal
 
     field :is_following do |talent, options|
-      options[:current_user]&.following&.where(user_id: talent.user_id)&.exists? || false
+      options[:current_user_watchlist]&.include?(talent.user_id) || false
     end
   end
 

--- a/app/controllers/api/v1/talent_controller.rb
+++ b/app/controllers/api/v1/talent_controller.rb
@@ -3,7 +3,7 @@ class API::V1::TalentController < ApplicationController
     service = Talents::Search.new(filter_params: filter_params.to_h)
     talents = service.call
 
-    render json: TalentBlueprint.render(talents.includes(:user, :token), view: :normal, current_user: current_user), status: :ok
+    render json: TalentBlueprint.render(talents.includes(:user, :token), view: :normal, current_user_watchlist: current_user_watchlist), status: :ok
   end
 
   # public /
@@ -15,7 +15,7 @@ class API::V1::TalentController < ApplicationController
         []
       end
 
-    render json: TalentBlueprint.render(talents, view: :normal, current_user: current_user), status: :ok
+    render json: TalentBlueprint.render(talents, view: :normal, current_user_watchlist: current_user_watchlist), status: :ok
   end
 
   # Public endpoint
@@ -23,7 +23,7 @@ class API::V1::TalentController < ApplicationController
     talent = Talent.joins(:token).find_by(token: {contract_id: params[:id]})
 
     if talent
-      render json: TalentBlueprint.render(talent, view: :normal, current_user: current_user), status: :ok
+      render json: TalentBlueprint.render(talent, view: :normal, current_user_watchlist: current_user_watchlist), status: :ok
     else
       render json: {error: "Not found."}, status: :not_found
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,4 +40,8 @@ class ApplicationController < ActionController::Base
   rescue
     0
   end
+
+  def current_user_watchlist
+    current_user ? current_user.following.pluck(:user_id) : []
+  end
 end

--- a/app/controllers/discovery_controller.rb
+++ b/app/controllers/discovery_controller.rb
@@ -33,4 +33,19 @@ class DiscoveryController < ApplicationController
     marketing_articles = MarketingArticle.all.order(created_at: :desc).limit(3)
     @marketing_articles = MarketingArticleBlueprint.render_as_json(marketing_articles, view: :normal)
   end
+
+  def show
+    @discovery_row = DiscoveryRow.find_by!(slug: params[:slug])
+
+    service = Talents::Search.new(filter_params: filter_params.to_h, discovery_row: @discovery_row)
+    talents = service.call
+
+    @talents = TalentBlueprint.render(talents.includes(:user, :token), view: :normal, current_user: current_user)
+  end
+
+  private
+
+  def filter_params
+    params.permit(:keyword, :status)
+  end
 end

--- a/app/controllers/discovery_controller.rb
+++ b/app/controllers/discovery_controller.rb
@@ -28,7 +28,7 @@ class DiscoveryController < ApplicationController
 
     @discovery_rows = DiscoveryRowBlueprint.render_as_json(
       discovery_rows,
-      view: :normal,
+      view: :with_talents,
       current_user_watchlist: current_user_watchlist
     )
 
@@ -42,7 +42,7 @@ class DiscoveryController < ApplicationController
     service = Talents::Search.new(filter_params: filter_params.to_h, discovery_row: discovery_row)
     talents = service.call
 
-    @discovery_row = DiscoveryRowBlueprint.render_as_json(discovery_row)
+    @discovery_row = DiscoveryRowBlueprint.render_as_json(discovery_row, view: :normal)
     @talents = TalentBlueprint.render_as_json(talents.includes(:user, :token), view: :normal, current_user_watchlist: current_user_watchlist)
 
     respond_to do |format|

--- a/app/controllers/discovery_controller.rb
+++ b/app/controllers/discovery_controller.rb
@@ -28,7 +28,7 @@ class DiscoveryController < ApplicationController
     @discovery_rows = DiscoveryRowBlueprint.render_as_json(
       discovery_rows,
       view: :normal,
-      current_user: current_user
+      current_user_watchlist: current_user_watchlist
     )
     marketing_articles = MarketingArticle.all.order(created_at: :desc).limit(3)
     @marketing_articles = MarketingArticleBlueprint.render_as_json(marketing_articles, view: :normal)
@@ -40,8 +40,8 @@ class DiscoveryController < ApplicationController
     service = Talents::Search.new(filter_params: filter_params.to_h, discovery_row: discovery_row)
     talents = service.call
 
-    @discovery_row = DiscoveryRowBlueprint.render_as_json(discovery_row, current_user: current_user)
-    @talents = TalentBlueprint.render_as_json(talents.includes(:user, :token), view: :normal, current_user: current_user)
+    @discovery_row = DiscoveryRowBlueprint.render_as_json(discovery_row)
+    @talents = TalentBlueprint.render_as_json(talents.includes(:user, :token), view: :normal, current_user_watchlist: current_user_watchlist)
 
     respond_to do |format|
       format.html

--- a/app/controllers/discovery_controller.rb
+++ b/app/controllers/discovery_controller.rb
@@ -14,6 +14,7 @@ class DiscoveryController < ApplicationController
 
       discovery_rows << {
         id: row.id,
+        slug: row.slug,
         title: row.title,
         badge: row.badge,
         badge_link: row.badge_link,
@@ -30,6 +31,7 @@ class DiscoveryController < ApplicationController
       view: :normal,
       current_user_watchlist: current_user_watchlist
     )
+
     marketing_articles = MarketingArticle.all.order(created_at: :desc).limit(3)
     @marketing_articles = MarketingArticleBlueprint.render_as_json(marketing_articles, view: :normal)
   end

--- a/app/controllers/discovery_controller.rb
+++ b/app/controllers/discovery_controller.rb
@@ -41,8 +41,17 @@ class DiscoveryController < ApplicationController
     talents = service.call
 
     @discovery_row = DiscoveryRowBlueprint.render_as_json(discovery_row, current_user: current_user)
-
     @talents = TalentBlueprint.render_as_json(talents.includes(:user, :token), view: :normal, current_user: current_user)
+
+    respond_to do |format|
+      format.html
+      format.json {
+        render(
+          json: @talents,
+          status: :ok
+        )
+      }
+    end
   end
 
   private

--- a/app/controllers/discovery_controller.rb
+++ b/app/controllers/discovery_controller.rb
@@ -35,12 +35,14 @@ class DiscoveryController < ApplicationController
   end
 
   def show
-    @discovery_row = DiscoveryRow.find_by!(slug: params[:slug])
+    discovery_row = DiscoveryRow.find_by!(slug: params[:slug])
 
-    service = Talents::Search.new(filter_params: filter_params.to_h, discovery_row: @discovery_row)
+    service = Talents::Search.new(filter_params: filter_params.to_h, discovery_row: discovery_row)
     talents = service.call
 
-    @talents = TalentBlueprint.render(talents.includes(:user, :token), view: :normal, current_user: current_user)
+    @discovery_row = DiscoveryRowBlueprint.render_as_json(discovery_row, current_user: current_user)
+
+    @talents = TalentBlueprint.render_as_json(talents.includes(:user, :token), view: :normal, current_user: current_user)
   end
 
   private

--- a/app/controllers/rewards_controller.rb
+++ b/app/controllers/rewards_controller.rb
@@ -16,7 +16,7 @@ class RewardsController < ApplicationController
       invite_ids = @talent_invites.map(&:id)
       talents = Talent.joins(:user).where(user: {invite_id: invite_ids})
 
-      @talent_list = TalentBlueprint.render_as_json(talents, view: :short_meta, current_user: current_user)
+      @talent_list = TalentBlueprint.render_as_json(talents, view: :short_meta, current_user_watchlist: current_user_watchlist)
     end
 
     quests = Quest.where(user: current_user).order(:id)

--- a/app/controllers/talent_controller.rb
+++ b/app/controllers/talent_controller.rb
@@ -2,7 +2,7 @@ class TalentController < ApplicationController
   def index
     service = Talents::Search.new(filter_params: filter_params.to_h)
     talents = service.call
-    @talents = talents.includes(:user, :token)
+    @talents = TalentBlueprint.render_as_json(talents.includes(:user, :token), view: :normal, current_user_watchlist: current_user_watchlist)
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,7 +27,7 @@ class UsersController < ApplicationController
       @talent = TalentBlueprint.render_as_json(
         talent,
         view: :extended,
-        current_user: current_user,
+        current_user_watchlist: current_user_watchlist,
         tags: @user.tags.where(hidden: false)
       )
     else

--- a/app/models/discovery_row.rb
+++ b/app/models/discovery_row.rb
@@ -1,3 +1,9 @@
 class DiscoveryRow < ApplicationRecord
+  extend FriendlyId
+
   has_many :tags
+
+  validates :title, :slug, presence: true, uniqueness: true
+
+  friendly_id :title, use: :slugged
 end

--- a/app/models/discovery_row.rb
+++ b/app/models/discovery_row.rb
@@ -1,4 +1,5 @@
 class DiscoveryRow < ApplicationRecord
+  include ::ProfilePictureUploader::Attachment(:logo)
   extend FriendlyId
 
   has_many :tags
@@ -6,4 +7,12 @@ class DiscoveryRow < ApplicationRecord
   validates :title, :slug, presence: true, uniqueness: true
 
   friendly_id :title, use: :slugged
+
+  def talents_count
+    Talent.base
+      .joins(:token)
+      .joins(user: {tags: :discovery_row})
+      .where(discovery_rows: {id: id})
+      .count
+  end
 end

--- a/app/models/discovery_row.rb
+++ b/app/models/discovery_row.rb
@@ -4,6 +4,8 @@ class DiscoveryRow < ApplicationRecord
 
   has_many :tags
 
+  has_many :visible_tags, -> { visible }, class_name: "Tag"
+
   validates :title, :slug, presence: true, uniqueness: true
 
   friendly_id :title, use: :slugged

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -5,6 +5,8 @@ class Tag < ApplicationRecord
 
   validates :description, presence: true
 
+  scope :visible, -> { where(hidden: false) }
+
   def to_s
     description
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,7 +1,9 @@
 class Tag < ApplicationRecord
-  has_one :discovery_row
+  belongs_to :discovery_row, optional: true
   has_many :user_tags
   has_many :talents, through: :user_tags
+
+  validates :description, presence: true
 
   def to_s
     description

--- a/app/packs/entrypoints/application.js
+++ b/app/packs/entrypoints/application.js
@@ -32,6 +32,7 @@ import EditTalent from "src/components/talent/Edit/Profile";
 import NewPortfolio from "src/components/portfolio/NewPortfolio";
 import EditSupporter from "src/components/supporters/edit/Profile";
 import Discovery from "src/components/discovery";
+import DiscoveryShow from "src/components/discovery/show";
 import TalentPage from "src/components/talent/TalentPage";
 import LoggedOutTopBar from "src/components/top_bar/LoggedOutTopBar";
 import SupporterProfile from "src/components/supporters/show/Profile";
@@ -44,31 +45,32 @@ import "stylesheets/application.scss";
 require.context("../images", true);
 
 ReactOnRails.register({
-  UpcomingTalents,
-  TalentShow,
-  MessageUserList,
-  Chat,
-  RegistrationFlow,
-  TalentKeywordSearch,
-  Login,
-  Web3ModalConnect,
-  TopBar,
-  Notifications,
-  WelcomePopup,
   BottomNav,
-  TopBar,
-  EditTalent,
-  NewPortfolio,
-  EditSupporter,
-  ResetPassword,
   ChangePassword,
+  Chat,
   Discovery,
-  TalentPage,
-  LoggedOutTopBar,
-  SupporterProfile,
-  Rewards,
-  QuestShow,
+  DiscoveryShow,
+  EditSupporter,
+  EditTalent,
   Footer,
+  LoggedOutTopBar,
+  Login,
+  MessageUserList,
+  NewPortfolio,
+  Notifications,
+  QuestShow,
+  RegistrationFlow,
+  ResetPassword,
+  Rewards,
+  SupporterProfile,
+  TalentKeywordSearch,
+  TalentPage,
+  TalentShow,
+  TopBar,
+  TopBar,
+  UpcomingTalents,
+  Web3ModalConnect,
+  WelcomePopup,
 });
 
 Rails.start();

--- a/app/packs/src/components/discovery/discovery_rows.jsx
+++ b/app/packs/src/components/discovery/discovery_rows.jsx
@@ -70,17 +70,17 @@ const DiscoveryRows = ({ discoveryRows, updateFollow }) => {
       return (
         <a
           href={row.badge_link}
-          className="cursor-pointer ml-2 "
+          className="cursor-pointer ml-2"
           target="_blank"
         >
-          <Tag className="bg-primary text-white cursor-pointer">
+          <Tag className=" cursor-pointer">
             <P3 className="current-color" bold text={row.badge} />
           </Tag>
         </a>
       );
     } else {
       return (
-        <Tag className="ml-2 bg-primary text-white">
+        <Tag className="ml-2">
           <P3 className="current-color" bold text={row.badge} />
         </Tag>
       );

--- a/app/packs/src/components/discovery/discovery_rows.jsx
+++ b/app/packs/src/components/discovery/discovery_rows.jsx
@@ -101,7 +101,7 @@ const DiscoveryRows = ({ discoveryRows, updateFollow }) => {
                     className={cx("text-black", mobile && "pl-4")}
                   />
                   <Link
-                    className="ml-5 d-flex align-items-center discover-all-link"
+                    className="mb-2 ml-5 d-flex align-items-center discover-all-link"
                     bold
                     href={`discovery/${row.slug}`}
                     text="Discover all"
@@ -112,7 +112,6 @@ const DiscoveryRows = ({ discoveryRows, updateFollow }) => {
                       className="rotate-270 ml-2"
                     />
                   </Link>
-
                   {!!row.badge && discoveryBadge(row)}
                 </div>
                 {row.talents.length > itemsPerRow(row.talents) && (

--- a/app/packs/src/components/discovery/discovery_rows.jsx
+++ b/app/packs/src/components/discovery/discovery_rows.jsx
@@ -100,8 +100,9 @@ const DiscoveryRows = ({ discoveryRows, updateFollow }) => {
                     text={row.title}
                     className={cx("text-black", mobile && "pl-4")}
                   />
+                  {!!row.badge && discoveryBadge(row)}
                   <Link
-                    className="mb-2 ml-5 d-flex align-items-center discover-all-link"
+                    className="mb-2 ml-3 d-flex align-items-center discover-all-link"
                     bold
                     href={`discovery/${row.slug}`}
                     text="Discover all"
@@ -112,7 +113,6 @@ const DiscoveryRows = ({ discoveryRows, updateFollow }) => {
                       className="rotate-270 ml-2"
                     />
                   </Link>
-                  {!!row.badge && discoveryBadge(row)}
                 </div>
                 {row.talents.length > itemsPerRow(row.talents) && (
                   <div className="d-flex flex-row">

--- a/app/packs/src/components/discovery/discovery_rows.jsx
+++ b/app/packs/src/components/discovery/discovery_rows.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from "react";
 import { useWindowDimensionsHook } from "src/utils/window";
 import { P1, P3 } from "src/components/design_system/typography";
+import Link from "src/components/design_system/link";
 import { Caret } from "src/components/icons";
 import NewTalentCard from "src/components/design_system/cards/NewTalentCard";
 import Button from "src/components/design_system/button";
@@ -89,7 +90,7 @@ const DiscoveryRows = ({ discoveryRows, updateFollow }) => {
   return (
     <>
       {discoveryRows.map((row) => (
-        <div key={row.title}>
+        <div key={row.title} className="discovery-row">
           {row.talents.length > 0 ? (
             <>
               <div className="d-flex justify-content-between">
@@ -99,6 +100,18 @@ const DiscoveryRows = ({ discoveryRows, updateFollow }) => {
                     text={row.title}
                     className={cx("text-black", mobile && "pl-4")}
                   />
+                  <Link
+                    className="ml-5 d-flex align-items-center discover-all-link"
+                    bold
+                    href={`discovery/${row.slug}`}
+                    text="Discover all"
+                  >
+                    <Caret
+                      size={12}
+                      color="currentColor"
+                      className="rotate-270 ml-2"
+                    />
+                  </Link>
 
                   {!!row.badge && discoveryBadge(row)}
                 </div>

--- a/app/packs/src/components/discovery/show.jsx
+++ b/app/packs/src/components/discovery/show.jsx
@@ -151,15 +151,17 @@ const DiscoveryShow = ({ discoveryRow, talents }) => {
         </a>
         <div className="d-flex align-items-center mb-3">
           <H3 className="text-black mr-2" bold text={discoveryRow.title} />
-          <Tooltip
-            body={discoveryRow.tags}
-            popOverAccessibilityId={"discovery_row_tags"}
-            placement="top"
-          >
-            <div className="cursor-pointer d-flex align-items-center">
-              <Help color="currentColor" />
-            </div>
-          </Tooltip>
+          {discoveryRow.tags && (
+            <Tooltip
+              body={discoveryRow.tags}
+              popOverAccessibilityId={"discovery_row_tags"}
+              placement="top"
+            >
+              <div className="cursor-pointer d-flex align-items-center">
+                <Help color="currentColor" />
+              </div>
+            </Tooltip>
+          )}
         </div>
         {discoveryRow.description && (
           <P1

--- a/app/packs/src/components/discovery/show.jsx
+++ b/app/packs/src/components/discovery/show.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useContext, useMemo } from "react";
-import { ArrowLeft } from "src/components/icons";
+import { ArrowLeft, Help } from "src/components/icons";
+import Tooltip from "src/components/design_system/tooltip";
 
 import { useWindowDimensionsHook } from "src/utils/window";
 
@@ -148,7 +149,18 @@ const DiscoveryShow = ({ discoveryRow, talents }) => {
             size={16}
           />
         </a>
-        <H3 className="text-black mb-3" bold text={discoveryRow.title} />
+        <div className="d-flex align-items-center mb-3">
+          <H3 className="text-black mr-2" bold text={discoveryRow.title} />
+          <Tooltip
+            body={discoveryRow.tags}
+            popOverAccessibilityId={"discovery_row_tags"}
+            placement="top"
+          >
+            <div className="cursor-pointer d-flex align-items-center">
+              <Help color="currentColor" />
+            </div>
+          </Tooltip>
+        </div>
         {discoveryRow.description && (
           <P1
             className="text-primary-03 mb-3"

--- a/app/packs/src/components/discovery/show.jsx
+++ b/app/packs/src/components/discovery/show.jsx
@@ -167,6 +167,7 @@ const DiscoveryShow = ({ discoveryRow, talents }) => {
       <TalentOptions
         headerDescription={`${discoveryRow.title} Talent List`}
         listModeOnly={listModeOnly}
+        searchUrl={`/discovery/${discoveryRow.slug}`}
         setListModeOnly={setListModeOnly}
         setLocalTalents={setLocalTalents}
         setSelectedSort={setSelectedSort}

--- a/app/packs/src/components/discovery/show.jsx
+++ b/app/packs/src/components/discovery/show.jsx
@@ -125,7 +125,7 @@ const DiscoveryShow = ({ discoveryRow, talents }) => {
       </div>
       <TalentOptions
         listModeOnly={listModeOnly}
-        discoveryRowId={discoveryRow.id}
+        searchUrl={`/discovery/${discoveryRow.slug}`}
         setListModeOnly={setListModeOnly}
         setLocalTalents={setLocalTalents}
         setSelectedSort={setSelectedSort}

--- a/app/packs/src/components/discovery/show.jsx
+++ b/app/packs/src/components/discovery/show.jsx
@@ -1,7 +1,5 @@
 import React, { useEffect, useState, useContext, useMemo } from "react";
-import { ethers } from "ethers";
 import { ArrowLeft } from "src/components/icons";
-import Button from "src/components/design_system/button";
 
 import { useWindowDimensionsHook } from "src/utils/window";
 
@@ -32,7 +30,7 @@ import TalentOptions from "src/components/talent/TalentOptions";
 
 import cx from "classnames";
 
-const DiscoveryShow = ({ discoveryRow, talents, userLoggedIn }) => {
+const DiscoveryShow = ({ discoveryRow, talents }) => {
   const theme = useContext(ThemeContext);
   const { mobile } = useWindowDimensionsHook();
   const [localTalents, setLocalTalents] = useState(talents);
@@ -145,7 +143,10 @@ const DiscoveryShow = ({ discoveryRow, talents, userLoggedIn }) => {
     <div className={cx(mobile && "p-4")}>
       <div className="talent-list-header  d-flex flex-column justify-content-center">
         <a className="button-link mb-5" href="/">
-          <ArrowLeft color="white" size={16} />
+          <ArrowLeft
+            color={theme.mode() == "light" ? "black" : "white"}
+            size={16}
+          />
         </a>
         <H3 className="text-black mb-3" bold text={discoveryRow.title} />
         {discoveryRow.description && (

--- a/app/packs/src/components/discovery/show.jsx
+++ b/app/packs/src/components/discovery/show.jsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState, useContext, useMemo } from "react";
 import { ethers } from "ethers";
+import { ArrowLeft } from "src/components/icons";
+import Button from "src/components/design_system/button";
 
 import { useWindowDimensionsHook } from "src/utils/window";
 
@@ -45,10 +47,6 @@ const DiscoveryShow = ({ discoveryRow, talents, userLoggedIn }) => {
   const [listModeOnly, setListModeOnly] = useState(false);
   const [selectedSort, setSelectedSort] = useState("");
   const [sortDirection, setSortDirection] = useState("asc");
-
-  const changeTab = (tab) => {
-    setWatchlistOnly(tab === "Watchlist" ? true : false);
-  };
 
   const updateFollow = async (talent) => {
     const newLocalTalents = localTalents.map((currTalent) => {
@@ -144,27 +142,34 @@ const DiscoveryShow = ({ discoveryRow, talents, userLoggedIn }) => {
   }, [data, loading]);
 
   return (
-    <div className={cx("pb-6", mobile && "p-4")}>
-      <div className="mb-5">
-        <H3
-          className="text-black mb-3"
-          bold
-          text={`${discoveryRow.title} Discovery Row`}
-        />
-        <P1
-          className="text-primary-03"
-          text="Support undiscovered talent and be rewarded as they grow."
-        />
+    <div className={cx(mobile && "p-4")}>
+      <div className="talent-list-header  d-flex flex-column justify-content-center">
+        <a className="button-link mb-5" href="/">
+          <ArrowLeft color="white" size={16} />
+        </a>
+        <H3 className="text-black mb-3" bold text={discoveryRow.title} />
+        {discoveryRow.description && (
+          <P1
+            className="text-primary-03 mb-3"
+            text={discoveryRow.description}
+          />
+        )}
+        <div className="d-flex">
+          <P1
+            bold
+            className="text-black d-inline mr-2"
+            text={discoveryRow.talentsCount}
+          />
+          <P1 className="text-primary-03 d-inline" text="talents" />
+        </div>
       </div>
       <TalentOptions
-        changeTab={changeTab}
+        headerDescription={`${discoveryRow.title} Talent List`}
         listModeOnly={listModeOnly}
-        searchUrl={`/discovery/${discoveryRow.slug}`}
         setListModeOnly={setListModeOnly}
         setLocalTalents={setLocalTalents}
         setSelectedSort={setSelectedSort}
         setSortDirection={setSortDirection}
-        userLoggedIn={userLoggedIn}
       />
       {localTalents.length === 0 && (
         <div className="d-flex justify-content-center mt-6">

--- a/app/packs/src/components/talent/TalentOptions.jsx
+++ b/app/packs/src/components/talent/TalentOptions.jsx
@@ -19,6 +19,7 @@ const TalentOptions = ({
   setLocalTalents,
   setSelectedSort,
   setSortDirection,
+  userLoggedIn,
 }) => {
   const { mobile } = useWindowDimensionsHook();
   const url = new URL(document.location);
@@ -60,7 +61,7 @@ const TalentOptions = ({
       className="mt-5 mb-6 d-flex flex-wrap justify-content-between"
       style={{ height: mobile ? "" : 34 }}
     >
-      {changeTab && (
+      {userLoggedIn && (
         <TabButton
           textTabPrimary="All Talent"
           textTabSecondary="Watchlist"

--- a/app/packs/src/components/talent/TalentOptions.jsx
+++ b/app/packs/src/components/talent/TalentOptions.jsx
@@ -13,6 +13,7 @@ import cx from "classnames";
 
 const TalentOptions = ({
   changeTab,
+  discoveryRowId,
   listModeOnly,
   setListModeOnly,
   setLocalTalents,
@@ -29,6 +30,7 @@ const TalentOptions = ({
 
     const params = new URLSearchParams(document.location.search);
     params.set(filterType, option);
+    params.set("discovery_row_id", discoveryRowId);
 
     get(`/api/v1/talent?${params.toString()}`).then((response) => {
       const talents = response.map((talent) => camelCaseObject(talent));
@@ -59,12 +61,14 @@ const TalentOptions = ({
       className="mt-5 mb-6 d-flex flex-wrap justify-content-between"
       style={{ height: mobile ? "" : 34 }}
     >
-      <TabButton
-        textTabPrimary="All Talent"
-        textTabSecondary="Watchlist"
-        onClick={(tab) => changeTab(tab)}
-      />
-      <div className={cx("d-flex", mobile && "mt-3")}>
+      {changeTab && (
+        <TabButton
+          textTabPrimary="All Talent"
+          textTabSecondary="Watchlist"
+          onClick={(tab) => changeTab(tab)}
+        />
+      )}
+      <div className={cx("d-flex ml-auto", mobile && "mt-3")}>
         <TalentKeywordSearch
           keyword={keyword}
           setKeyword={setKeyword}

--- a/app/packs/src/components/talent/TalentOptions.jsx
+++ b/app/packs/src/components/talent/TalentOptions.jsx
@@ -8,6 +8,7 @@ import TalentFilters from "./TalentFilters";
 import { Grid, List } from "src/components/icons";
 import { useWindowDimensionsHook } from "src/utils/window";
 import { camelCaseObject } from "src/utils/transformObjects";
+import { P1 } from "src/components/design_system/typography";
 
 import cx from "classnames";
 
@@ -15,11 +16,11 @@ const TalentOptions = ({
   changeTab,
   searchUrl,
   listModeOnly,
+  headerDescription,
   setListModeOnly,
   setLocalTalents,
   setSelectedSort,
   setSortDirection,
-  userLoggedIn,
 }) => {
   const { mobile } = useWindowDimensionsHook();
   const url = new URL(document.location);
@@ -58,10 +59,12 @@ const TalentOptions = ({
 
   return (
     <div
-      className="mt-5 mb-6 d-flex flex-wrap justify-content-between"
+      className="mt-5 mb-6 d-flex flex-wrap justify-content-between align-items-center"
       style={{ height: mobile ? "" : 34 }}
     >
-      {userLoggedIn && (
+      {headerDescription ? (
+        <P1 bold className="text-black" text={headerDescription} />
+      ) : (
         <TabButton
           textTabPrimary="All Talent"
           textTabSecondary="Watchlist"

--- a/app/packs/src/components/talent/TalentOptions.jsx
+++ b/app/packs/src/components/talent/TalentOptions.jsx
@@ -13,7 +13,7 @@ import cx from "classnames";
 
 const TalentOptions = ({
   changeTab,
-  discoveryRowId,
+  searchUrl,
   listModeOnly,
   setListModeOnly,
   setLocalTalents,
@@ -30,9 +30,8 @@ const TalentOptions = ({
 
     const params = new URLSearchParams(document.location.search);
     params.set(filterType, option);
-    params.set("discovery_row_id", discoveryRowId);
 
-    get(`/api/v1/talent?${params.toString()}`).then((response) => {
+    get(`${searchUrl}?${params.toString()}`).then((response) => {
       const talents = response.map((talent) => camelCaseObject(talent));
 
       if (option === "Trending") {

--- a/app/packs/src/components/talent/TalentPage.jsx
+++ b/app/packs/src/components/talent/TalentPage.jsx
@@ -147,7 +147,7 @@ const TalentPage = ({ talents }) => {
 
   return (
     <div className={cx("pb-6", mobile && "p-4")}>
-      <div className="mb-5">
+      <div className="mb-5 talent-list-header d-flex flex-column justify-content-center">
         <H3 className="text-black mb-3" bold text="Explore All Talent" />
         <P1
           className="text-primary-03"

--- a/app/packs/src/components/talent/TalentPage.jsx
+++ b/app/packs/src/components/talent/TalentPage.jsx
@@ -157,6 +157,7 @@ const TalentPage = ({ talents }) => {
       <TalentOptions
         changeTab={changeTab}
         listModeOnly={listModeOnly}
+        searchUrl="/api/v1/talent"
         setListModeOnly={setListModeOnly}
         setLocalTalents={setLocalTalents}
         setSelectedSort={setSelectedSort}

--- a/app/packs/src/components/talent/utils/talent.js
+++ b/app/packs/src/components/talent/utils/talent.js
@@ -1,3 +1,6 @@
+import { compareStrings, compareNumbers } from "src/utils/compareHelpers";
+import { ethers } from "ethers";
+
 export const completeProfile = (args) => {
   return missingFields(args).length == 0;
 };
@@ -69,4 +72,24 @@ export const profileProgress = ({
   }
 
   return total - fields.length * 10;
+};
+
+export const compareName = (talent1, talent2) =>
+  compareStrings(talent1.user.name, talent2.user.name);
+
+export const compareOccupation = (talent1, talent2) =>
+  compareStrings(talent1.occupation, talent2.occupation);
+
+export const compareSupporters = (talent1, talent2) =>
+  compareNumbers(talent1.supporterCounter, talent2.supporterCounter);
+
+export const compareMarketCap = (talent1, talent2) => {
+  const talent1Amount = ethers.utils.parseUnits(
+    talent1.marketCap?.replaceAll(",", "") || "0"
+  );
+  const talent2Amount = ethers.utils.parseUnits(
+    talent2.marketCap?.replaceAll(",", "") || "0"
+  );
+
+  return compareNumbers(talent1Amount, talent2Amount);
 };

--- a/app/packs/src/utils/requests.js
+++ b/app/packs/src/utils/requests.js
@@ -1,8 +1,15 @@
 const getAuthToken = () =>
   document.querySelector('meta[name="csrf-token"]')?.content;
 
+const defaultHeaders = () => {
+  return {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  };
+};
+
 const post = (url, content) => {
-  const headers = { "Content-Type": "application/json" };
+  const headers = defaultHeaders();
 
   if (getAuthToken) {
     headers["X-CSRF-Token"] = getAuthToken();
@@ -21,7 +28,7 @@ const post = (url, content) => {
 };
 
 const put = (url, content) => {
-  const headers = { "Content-Type": "application/json" };
+  const headers = defaultHeaders();
 
   if (getAuthToken) {
     headers["X-CSRF-Token"] = getAuthToken();
@@ -40,7 +47,7 @@ const put = (url, content) => {
 };
 
 const patch = (url, content) => {
-  const headers = { "Content-Type": "application/json" };
+  const headers = defaultHeaders();
 
   if (getAuthToken) {
     headers["X-CSRF-Token"] = getAuthToken();
@@ -59,7 +66,7 @@ const patch = (url, content) => {
 };
 
 const get = (url) => {
-  const headers = { "Content-Type": "application/json" };
+  const headers = defaultHeaders();
 
   if (getAuthToken) {
     headers["X-CSRF-Token"] = getAuthToken();
@@ -84,7 +91,7 @@ const externalGet = (url, params = {}) => {
 };
 
 const destroy = (url, content) => {
-  const headers = { "Content-Type": "application/json" };
+  const headers = defaultHeaders();
 
   if (getAuthToken) {
     headers["X-CSRF-Token"] = getAuthToken();

--- a/app/packs/stylesheets/application.scss
+++ b/app/packs/stylesheets/application.scss
@@ -6,6 +6,7 @@
 @import "custom/slider";
 @import "custom/tooltip";
 @import "custom/checkbox";
+@import "custom/discovery";
 @import "custom/fields";
 @import "custom/chat";
 @import "custom/talent";

--- a/app/packs/stylesheets/custom/_discovery.scss
+++ b/app/packs/stylesheets/custom/_discovery.scss
@@ -1,0 +1,18 @@
+@import "../bootstrap/overrides";
+
+// Discovery page
+
+.discovery-row {
+  .discover-all-link {
+    display: none;
+    transition: opacity 0.5s ease-out;
+    opacity: 0;
+  }
+
+  &:hover {
+    .discover-all-link {
+      opacity: 1;
+      display: flex;
+    }
+  }
+}

--- a/app/packs/stylesheets/custom/_tags.scss
+++ b/app/packs/stylesheets/custom/_tags.scss
@@ -7,7 +7,7 @@
   width: fit-content;
   padding: 2px 8px;
   border-radius: 4px;
-  background-color: $surface-hover;
+  background-color: $primary-disabled;
 
   &.primary {
     background-color: $primary-200;
@@ -15,7 +15,7 @@
 }
 
 .dark-body .tag-container {
-  background-color: $gray-800;
+  background-color: $primary-shade-01;
 }
 
 .optional-tag-container {

--- a/app/packs/stylesheets/custom/_talent.scss
+++ b/app/packs/stylesheets/custom/_talent.scss
@@ -24,6 +24,24 @@
   border: 8px solid $dark-bg-01;
 }
 
+.dark-body .talent-list-header {
+  height: 277px;
+  margin-top: -40px;
+
+  &::before {
+    background-color: $gray-900;
+    content: "";
+    height: inherit;
+    z-index: -1;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100vw;
+    border-bottom: 1px solid $gray-800;
+    margin-top: 66px;
+  }
+}
+
 .pull-bottom-content {
   margin-bottom: -40px;
 }
@@ -168,5 +186,22 @@
     margin-left: 0;
     padding-left: 0;
     padding-right: 8px;
+  }
+
+  .dark-body .talent-list-header {
+    height: 240px;
+
+    &::before {
+      background-color: $gray-900;
+      content: "";
+      height: inherit;
+      z-index: -1;
+      left: 0;
+      position: absolute;
+      top: 0;
+      width: 100vw;
+      border-bottom: 1px solid $gray-800;
+      margin-top: 66px;
+    }
   }
 }

--- a/app/views/discovery/index.html.erb
+++ b/app/views/discovery/index.html.erb
@@ -3,9 +3,10 @@
     <%= react_component("Discovery",
       props: {
         discoveryRows: @discovery_rows.map { |row| {
-          title: row["title"],
           badge: row["badge"],
           badge_link: row["badge_link"],
+          slug: row["slug"],
+          title: row["title"],
           talents: row["talents"].map { |talent| {
             id: talent["id"],
             profilePictureUrl: talent["profile_picture_url"],

--- a/app/views/discovery/show.html.erb
+++ b/app/views/discovery/show.html.erb
@@ -1,5 +1,11 @@
 <main class="main-content">
   <div class="container-grid">
+    <% if current_user.nil? %>
+      <%= react_component("LoggedOutTopBar", props:
+        {
+        }, prerender: false)
+      %>
+    <% end %>
     <div class="secondary-content">
       <%= react_component("DiscoveryShow",
         props: {
@@ -26,7 +32,8 @@
             badge_link: @discovery_row["badge_link"],
             slug: @discovery_row["slug"],
             title: @discovery_row["title"],
-          }
+          },
+          userLoggedIn: current_user.present?
         },
         prerender: false) %>
     </div>

--- a/app/views/discovery/show.html.erb
+++ b/app/views/discovery/show.html.erb
@@ -17,6 +17,7 @@
                 username: talent["user"]["username"],
                 name: talent["user"]["display_name"] || talent["user"]["username"]
               },
+              isFollowing: talent['is_following'],
               userId: talent["user_id"]
             }
           },

--- a/app/views/discovery/show.html.erb
+++ b/app/views/discovery/show.html.erb
@@ -34,6 +34,7 @@
             logoUrl: @discovery_row["logo_url"],
             talentsCount: @discovery_row["talents_count"],
             slug: @discovery_row["slug"],
+            tags: @discovery_row["tags"].map { |tag| tag["description"] }.join(", "),
             title: @discovery_row["title"],
           }
         },

--- a/app/views/discovery/show.html.erb
+++ b/app/views/discovery/show.html.erb
@@ -1,5 +1,33 @@
 <main class="main-content">
   <div class="container-grid">
-    
+    <div class="secondary-content">
+      <%= react_component("DiscoveryShow",
+        props: {
+          talents: @talents.map { |talent|
+            {
+              id: talent["id"],
+              profilePictureUrl: talent["profile_picture_url"],
+              occupation: talent["occupation"],
+              headline: talent["headline"],
+              token: {
+                ticker: talent["token"]["ticker"],
+                contractId: talent["token"]["contract_id"]
+              },
+              user: {
+                username: talent["user"]["username"],
+                name: talent["user"]["display_name"] || talent["user"]["username"]
+              },
+              userId: talent["user_id"]
+            }
+          },
+          discoveryRow: {
+            id: @discovery_row["id"],
+            title: @discovery_row["title"],
+            badge: @discovery_row["badge"],
+            badge_link: @discovery_row["badge_link"],
+          }
+        },
+        prerender: false) %>
+    </div>
   </div>
 </main>

--- a/app/views/discovery/show.html.erb
+++ b/app/views/discovery/show.html.erb
@@ -34,7 +34,7 @@
             logoUrl: @discovery_row["logo_url"],
             talentsCount: @discovery_row["talents_count"],
             slug: @discovery_row["slug"],
-            tags: @discovery_row["tags"].map { |tag| tag["description"] }.join(", "),
+            tags: @discovery_row["visible_tags"].map { |tag| tag["description"] }.join(", "),
             title: @discovery_row["title"],
           }
         },

--- a/app/views/discovery/show.html.erb
+++ b/app/views/discovery/show.html.erb
@@ -1,0 +1,5 @@
+<main class="main-content">
+  <div class="container-grid">
+    
+  </div>
+</main>

--- a/app/views/discovery/show.html.erb
+++ b/app/views/discovery/show.html.erb
@@ -21,10 +21,10 @@
             }
           },
           discoveryRow: {
-            id: @discovery_row["id"],
-            title: @discovery_row["title"],
             badge: @discovery_row["badge"],
             badge_link: @discovery_row["badge_link"],
+            slug: @discovery_row["slug"],
+            title: @discovery_row["title"],
           }
         },
         prerender: false) %>

--- a/app/views/discovery/show.html.erb
+++ b/app/views/discovery/show.html.erb
@@ -29,11 +29,13 @@
           },
           discoveryRow: {
             badge: @discovery_row["badge"],
-            badge_link: @discovery_row["badge_link"],
+            badgeLink: @discovery_row["badge_link"],
+            description: @discovery_row["description"],
+            logoUrl: @discovery_row["logo_url"],
+            talentsCount: @discovery_row["talents_count"],
             slug: @discovery_row["slug"],
             title: @discovery_row["title"],
-          },
-          userLoggedIn: current_user.present?
+          }
         },
         prerender: false) %>
     </div>

--- a/app/views/talent/index.html.erb
+++ b/app/views/talent/index.html.erb
@@ -3,22 +3,22 @@
     <div class="secondary-content">
       <%= react_component("TalentPage",
         props: {
-          talents: @talents.map { |talent|
+           talents: @talents.map { |talent|
             {
-              id: talent.id,
-              profilePictureUrl: talent.profile_picture_url,
-              occupation: talent.occupation,
-              headline: talent.headline,
+              id: talent["id"],
+              profilePictureUrl: talent["profile_picture_url"],
+              occupation: talent["occupation"],
+              headline: talent["headline"],
               token: {
-                ticker: talent.token.ticker,
-                contractId: talent.token.contract_id
+                ticker: talent["token"]["ticker"],
+                contractId: talent["token"]["contract_id"]
               },
               user: {
-                username: talent.user.username,
-                name: talent.user.display_name || talent.user.username
+                username: talent["user"]["username"],
+                name: talent["user"]["display_name"] || talent["user"]["username"]
               },
-              isFollowing: current_user.following.where(user_id: talent.user_id).exists?,
-              userId: talent.user_id
+              isFollowing: talent['is_following'],
+              userId: talent["user_id"]
             }
           }
         },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,9 @@ Rails.application.routes.draw do
   end
 
   # Public routes
+
+  resources :discovery, only: [:show], param: :slug
+
   # Auth - Clearance generated routes
   resources :passwords, controller: "passwords", only: [:create, :new]
   resource :session, controller: "sessions", only: [:create]

--- a/db/migrate/20220506122951_add_fields_to_discovery_rows.rb
+++ b/db/migrate/20220506122951_add_fields_to_discovery_rows.rb
@@ -1,0 +1,7 @@
+class AddFieldsToDiscoveryRows < ActiveRecord::Migration[6.1]
+  def change
+    add_column :discovery_rows, :slug, :string, unique: true
+    add_column :discovery_rows, :description, :text
+    add_column :discovery_rows, :logo_data, :text
+  end
+end

--- a/db/migrate/20220506122951_add_slug_to_discovery_row.rb
+++ b/db/migrate/20220506122951_add_slug_to_discovery_row.rb
@@ -1,5 +1,0 @@
-class AddSlugToDiscoveryRow < ActiveRecord::Migration[6.1]
-  def change
-    add_column :discovery_rows, :slug, :string, unique: true
-  end
-end

--- a/db/migrate/20220506122951_add_slug_to_discovery_row.rb
+++ b/db/migrate/20220506122951_add_slug_to_discovery_row.rb
@@ -1,0 +1,5 @@
+class AddSlugToDiscoveryRow < ActiveRecord::Migration[6.1]
+  def change
+    add_column :discovery_rows, :slug, :string, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_06_122951) do
+ActiveRecord::Schema.define(version: 2022_04_21_145232) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,6 +24,17 @@ ActiveRecord::Schema.define(version: 2022_05_06_122951) do
     t.string "pitch"
     t.string "challenges"
     t.index ["talent_id"], name: "index_career_goals_on_talent_id"
+  end
+
+  create_table "chats", force: :cascade do |t|
+    t.datetime "last_message_at", null: false
+    t.bigint "sender_id", null: false
+    t.bigint "receiver_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["receiver_id"], name: "index_chats_on_receiver_id"
+    t.index ["sender_id", "receiver_id"], name: "index_chats_on_sender_id_and_receiver_id", unique: true
+    t.index ["sender_id"], name: "index_chats_on_sender_id"
   end
 
   create_table "comments", force: :cascade do |t|
@@ -126,6 +137,9 @@ ActiveRecord::Schema.define(version: 2022_05_06_122951) do
     t.text "text_ciphertext"
     t.boolean "is_read", default: false, null: false
     t.boolean "sent_to_supporters", default: false
+    t.text "last_message_text_ciphertext"
+    t.bigint "chat_id"
+    t.index ["chat_id"], name: "index_messages_on_chat_id"
     t.index ["receiver_id"], name: "index_messages_on_receiver_id"
     t.index ["sender_id"], name: "index_messages_on_sender_id"
   end
@@ -254,8 +268,11 @@ ActiveRecord::Schema.define(version: 2022_05_06_122951) do
   end
 
   create_table "tasks", force: :cascade do |t|
+    t.string "title"
+    t.string "description"
+    t.string "reward"
     t.string "status", default: "pending"
-    t.string "type"
+    t.string "link"
     t.bigint "quest_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -349,6 +366,8 @@ ActiveRecord::Schema.define(version: 2022_05_06_122951) do
   end
 
   add_foreign_key "career_goals", "talent"
+  add_foreign_key "chats", "users", column: "receiver_id"
+  add_foreign_key "chats", "users", column: "sender_id"
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
   add_foreign_key "feed_posts", "feeds"
@@ -359,6 +378,7 @@ ActiveRecord::Schema.define(version: 2022_05_06_122951) do
   add_foreign_key "goals", "career_goals"
   add_foreign_key "invites", "users"
   add_foreign_key "marketing_articles", "users"
+  add_foreign_key "messages", "chats"
   add_foreign_key "milestones", "talent"
   add_foreign_key "perks", "talent"
   add_foreign_key "posts", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_21_145232) do
+ActiveRecord::Schema.define(version: 2022_05_06_122951) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,17 +25,6 @@ ActiveRecord::Schema.define(version: 2022_04_21_145232) do
     t.string "pitch"
     t.string "challenges"
     t.index ["talent_id"], name: "index_career_goals_on_talent_id"
-  end
-
-  create_table "chats", force: :cascade do |t|
-    t.datetime "last_message_at", null: false
-    t.bigint "sender_id", null: false
-    t.bigint "receiver_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["receiver_id"], name: "index_chats_on_receiver_id"
-    t.index ["sender_id", "receiver_id"], name: "index_chats_on_sender_id_and_receiver_id", unique: true
-    t.index ["sender_id"], name: "index_chats_on_sender_id"
   end
 
   create_table "comments", force: :cascade do |t|
@@ -54,6 +44,8 @@ ActiveRecord::Schema.define(version: 2022_04_21_145232) do
     t.string "badge"
     t.string "badge_link"
     t.string "slug"
+    t.text "description"
+    t.text "logo_data"
   end
 
   create_table "feed_posts", force: :cascade do |t|
@@ -137,9 +129,6 @@ ActiveRecord::Schema.define(version: 2022_04_21_145232) do
     t.text "text_ciphertext"
     t.boolean "is_read", default: false, null: false
     t.boolean "sent_to_supporters", default: false
-    t.text "last_message_text_ciphertext"
-    t.bigint "chat_id"
-    t.index ["chat_id"], name: "index_messages_on_chat_id"
     t.index ["receiver_id"], name: "index_messages_on_receiver_id"
     t.index ["sender_id"], name: "index_messages_on_sender_id"
   end
@@ -268,11 +257,8 @@ ActiveRecord::Schema.define(version: 2022_04_21_145232) do
   end
 
   create_table "tasks", force: :cascade do |t|
-    t.string "title"
-    t.string "description"
-    t.string "reward"
     t.string "status", default: "pending"
-    t.string "link"
+    t.string "type"
     t.bigint "quest_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -366,8 +352,6 @@ ActiveRecord::Schema.define(version: 2022_04_21_145232) do
   end
 
   add_foreign_key "career_goals", "talent"
-  add_foreign_key "chats", "users", column: "receiver_id"
-  add_foreign_key "chats", "users", column: "sender_id"
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
   add_foreign_key "feed_posts", "feeds"
@@ -378,7 +362,6 @@ ActiveRecord::Schema.define(version: 2022_04_21_145232) do
   add_foreign_key "goals", "career_goals"
   add_foreign_key "invites", "users"
   add_foreign_key "marketing_articles", "users"
-  add_foreign_key "messages", "chats"
   add_foreign_key "milestones", "talent"
   add_foreign_key "perks", "talent"
   add_foreign_key "posts", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_21_115233) do
-
+ActiveRecord::Schema.define(version: 2022_05_06_122951) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -43,6 +42,7 @@ ActiveRecord::Schema.define(version: 2022_04_21_115233) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "badge"
     t.string "badge_link"
+    t.string "slug"
   end
 
   create_table "feed_posts", force: :cascade do |t|

--- a/lib/tasks/discovery_rows.rake
+++ b/lib/tasks/discovery_rows.rake
@@ -1,0 +1,6 @@
+namespace :discovery_rows do
+  task set_slug: :environment do
+    # Saving the discovery row will set the slug based on the title
+    DiscoveryRow.find_each { |row| row.save! }
+  end
+end

--- a/spec/factories/discovery_rows.rb
+++ b/spec/factories/discovery_rows.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :discovery_row do
+    sequence :title do |n|
+      "Title #{n}"
+    end
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,4 +1,7 @@
 FactoryBot.define do
   factory :tag do
+    sequence :description do |n|
+      "description_#{n}"
+    end
   end
 end

--- a/spec/models/discovery_row_spec.rb
+++ b/spec/models/discovery_row_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe DiscoveryRow, type: :model do
   describe "associations" do
     it { is_expected.to have_many(:tags) }
+    it { is_expected.to have_many(:visible_tags) }
   end
 
   describe "validations" do

--- a/spec/models/discovery_row_spec.rb
+++ b/spec/models/discovery_row_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe DiscoveryRow, type: :model do
+  describe "associations" do
+    it { is_expected.to have_many(:tags) }
+  end
+
+  describe "validations" do
+    subject { build :discovery_row }
+
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_uniqueness_of(:title) }
+    it { is_expected.to validate_uniqueness_of(:slug) }
+  end
+
+  describe "#slug" do
+    let(:discovery_row) { build :discovery_row, title: "Talent Protocol Team" }
+
+    it "generates a slug based on the title on save" do
+      discovery_row.save!
+
+      expect(discovery_row.slug).to eq "talent-protocol-team"
+    end
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Tag, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:discovery_row).optional }
+    it { is_expected.to have_many(:user_tags) }
+    it { is_expected.to have_many(:talents).through(:user_tags) }
+  end
+
+  describe "validations" do
+    subject { build :tag }
+
+    it { is_expected.to validate_presence_of(:description) }
+  end
+
+  describe "#to_s" do
+    let(:tag) { build :tag, description: "Web3" }
+
+    it "returns the tag description" do
+      expect(tag.to_s).to eq tag.description
+    end
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe Tag, type: :model do
     it { is_expected.to validate_presence_of(:description) }
   end
 
+  describe ".visible" do
+    let!(:tag_one) { create :tag, hidden: false }
+    let!(:tag_two) { create :tag, hidden: true }
+
+    it "returns only visible tags" do
+      expect(Tag.visible).to match_array [tag_one]
+    end
+  end
+
   describe "#to_s" do
     let(:tag) { build :tag, description: "Web3" }
 

--- a/spec/requests/discovery_rows_spec.rb
+++ b/spec/requests/discovery_rows_spec.rb
@@ -1,8 +1,11 @@
 require "rails_helper"
 
 RSpec.shared_examples "a discovery row get endpoint request" do
-  let!(:talent_one) { create :talent }
-  let!(:talent_two) { create :talent }
+  let!(:talent_one) { create :talent, user: create(:user) }
+  let!(:talent_two) { create :talent, user: create(:user) }
+
+  let!(:token_one) { create :token, talent: talent_one }
+  let!(:token_two) { create :token, talent: talent_two }
 
   let(:search_talents_class) { Talents::Search }
   let(:search_talents_instance) { instance_double(Talents::Search, call: Talent.all) }
@@ -15,7 +18,7 @@ RSpec.shared_examples "a discovery row get endpoint request" do
     let!(:discovery_row) { create :discovery_row }
     let(:slug) { discovery_row.slug }
 
-    it "returns a successful response" do
+    fit "returns a successful response" do
       get_discovery_row
 
       expect(response).to have_http_status(:ok)

--- a/spec/requests/discovery_rows_spec.rb
+++ b/spec/requests/discovery_rows_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.shared_examples "a discovery row get endpoint request" do
+  let!(:talent_one) { create :talent }
+  let!(:talent_two) { create :talent }
+
+  let(:search_talents_class) { Talents::Search }
+  let(:search_talents_instance) { instance_double(Talents::Search, call: Talent.all) }
+
+  before do
+    allow(search_talents_class).to receive(:new).and_return(search_talents_instance)
+  end
+
+  context "when the discovery row passed exists" do
+    let!(:discovery_row) { create :discovery_row }
+    let(:slug) { discovery_row.slug }
+
+    it "returns a successful response" do
+      get_discovery_row
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "searches talents that belong to the discovery row" do
+      get_discovery_row
+
+      aggregate_failures do
+        expect(search_talents_class).to have_received(:new)
+        expect(search_talents_instance).to have_received(:call)
+      end
+    end
+
+    it "assigns the correct objects to be passed to the view" do
+      get_discovery_row
+
+      expect(assigns(:discovery_row)).to eq(discovery_row)
+      expect(assigns(:talents)).to eq(discovery_row)
+    end
+  end
+
+  context "when the discovery row passed does not exist" do
+    let(:slug) { "random" }
+
+    it "returns a not found response" do
+      get_discovery_row
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end
+
+RSpec.describe "Discovery rows", type: :request do
+  describe "#show" do
+    subject(:get_discovery_row) { get discovery_path(slug: slug, params: params, as: current_user) }
+
+    let(:params) do
+      {
+        user: {
+          keyword: "johndoe",
+          status: "Launching soon"
+        }
+      }
+    end
+
+    context "when the current user is nil" do
+      let(:current_user) { nil }
+
+      it_behaves_like "a discovery row get endpoint request"
+    end
+
+    context "when the current user is passed" do
+      let(:current_user) { create :user }
+
+      it_behaves_like "a discovery row get endpoint request"
+    end
+  end
+end

--- a/spec/requests/discovery_rows_spec.rb
+++ b/spec/requests/discovery_rows_spec.rb
@@ -36,7 +36,7 @@ RSpec.shared_examples "a discovery row get endpoint request" do
     it "assigns the correct objects to be passed to the view" do
       get_discovery_row
 
-      expect(assigns(:discovery_row)).to eq(DiscoveryRowBlueprint.render_as_json(discovery_row))
+      expect(assigns(:discovery_row)).to eq(DiscoveryRowBlueprint.render_as_json(discovery_row, view: :normal))
       expect(assigns(:talents)).to eq(TalentBlueprint.render_as_json([talent_one, talent_two], view: :normal))
     end
   end

--- a/spec/requests/discovery_rows_spec.rb
+++ b/spec/requests/discovery_rows_spec.rb
@@ -18,7 +18,7 @@ RSpec.shared_examples "a discovery row get endpoint request" do
     let!(:discovery_row) { create :discovery_row }
     let(:slug) { discovery_row.slug }
 
-    fit "returns a successful response" do
+    it "returns a successful response" do
       get_discovery_row
 
       expect(response).to have_http_status(:ok)
@@ -36,8 +36,8 @@ RSpec.shared_examples "a discovery row get endpoint request" do
     it "assigns the correct objects to be passed to the view" do
       get_discovery_row
 
-      expect(assigns(:discovery_row)).to eq(discovery_row)
-      expect(assigns(:talents)).to eq(discovery_row)
+      expect(assigns(:discovery_row)).to eq(DiscoveryRowBlueprint.render_as_json(discovery_row))
+      expect(assigns(:talents)).to eq(TalentBlueprint.render_as_json([talent_one, talent_two], view: :normal))
     end
   end
 

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Messages", type: :request do
         }
       end
 
-      it "returns a bad request response" do
+      it "returns a not found response" do
         post messages_path(params: params, as: user)
 
         expect(response).to have_http_status(:not_found)


### PR DESCRIPTION
## Summary

This PR adds the discovery row pages. We're adding them to showcase talent inside particular areas, such as web3, desing, development, etc. The pages should be public accessible.

## Notion link

https://talentprotocol.notion.site/Improve-Discover-Page-Automation-2645e05c601945d2b1cffa339d4c8d10

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
