### PR TITLE
Adjust CI action to upload test coverage report on another workflow

### DIFF
--- a/.github/workflows/talent_ci.yml
+++ b/.github/workflows/talent_ci.yml
@@ -10,11 +10,6 @@ on:
       - dev
       - master
     types: [ready_for_review, opened, reopened, synchronize]
-  pull_request_target:
-    branches:
-      - dev
-      - master
-    types: [ready_for_review, opened, reopened, synchronize]
 
 concurrency:
   group: talent-${{ github.head_ref || github.run_id }}
@@ -136,35 +131,3 @@ jobs:
           name: code-coverage
           path: coverage/
           retention-days: 1
-
-  finalize:
-    needs: [talent-lint, talent-rspec]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Set up Ruby and install gems
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby-version }}
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-
-      - name: Download coverage
-        uses: actions/download-artifact@v2
-        with:
-          name: code-coverage
-          path: coverage-matrix
-
-      - name: Collate Simplecov results
-        env:
-          GITHUB_ARTIFACTS: coverage
-          GITHUB_DOWNLOADED_ARTIFACTS: coverage-matrix
-        run: |
-          bundle exec rake coverage:report
-
-      - name: Simplecov Report
-        uses: aki77/simplecov-report-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          failedThreshold: 6

--- a/.github/workflows/talent_coverage.yml
+++ b/.github/workflows/talent_coverage.yml
@@ -1,0 +1,45 @@
+name: Talent Protocol - Coverage
+
+on:
+  workflow_run:
+    workflows: [Talent Protocol - CI]
+    types:
+      - completed
+
+jobs:
+  upload_coverage:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ["2.7.3"]
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - name: Download coverage
+        uses: actions/download-artifact@v2
+        with:
+          name: code-coverage
+          path: coverage-matrix
+
+      - name: Collate Simplecov results
+        env:
+          GITHUB_ARTIFACTS: coverage
+          GITHUB_DOWNLOADED_ARTIFACTS: coverage-matrix
+        run: |
+          bundle exec rake coverage:report
+
+      - name: Simplecov Report
+        uses: aki77/simplecov-report-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          failedThreshold: 10


### PR DESCRIPTION
## Summary

This PR adds a new independent workflow to manage test coverage reports on pull requests. With this approach contributors will be able to see test coverage reports on pull requests.

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
