### PR TITLE
Add lib to download artifacts from different workflows

### DIFF
--- a/.github/workflows/talent_coverage.yml
+++ b/.github/workflows/talent_coverage.yml
@@ -26,10 +26,12 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Download coverage
-        uses: actions/download-artifact@v2
+        uses: dawidd6/action-download-artifact@v2
         with:
           name: code-coverage
           path: coverage-matrix
+          workflow: ${{ github.event.workflow.id }}
+          pr: ${{ github.event.pull_request.number }}
 
       - name: Collate Simplecov results
         env:


### PR DESCRIPTION
## Summary

This PR adds a new lib to download artifacts from a different github workflow. This will allow computing the code coverage.

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
