### PR TITLE
Add profile type to user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,14 @@ class User < ApplicationRecord
 
   VALID_ROLES = ["admin", "basic"].freeze
 
+  enum profile_type: {
+    supporter: "supporter",
+    applying: "applying",
+    waiting_for_approval: "waiting_for_approval",
+    approved: "approved",
+    talent: "talent"
+  }
+
   module Delivery
     TYPES = [
       MessageReceivedNotification,

--- a/app/services/destroy_user.rb
+++ b/app/services/destroy_user.rb
@@ -36,10 +36,6 @@ class DestroyUser
           user.talent.perks.destroy_all
         end
 
-        if user.talent.tags.exists?
-          user.talent.tags.destroy_all
-        end
-
         if user.talent.milestones.exists?
           user.talent.milestones.destroy_all
         end
@@ -51,6 +47,7 @@ class DestroyUser
       Message.where(sender_id: user.id).destroy_all
       Message.where(receiver_id: user.id).destroy_all
       Quest.where(user: user).destroy_all
+      UserTag.where(user: user).destroy_all
 
       user.destroy!
     end

--- a/app/services/supporter/upgrade_to_talent.rb
+++ b/app/services/supporter/upgrade_to_talent.rb
@@ -41,10 +41,6 @@ class Supporter::UpgradeToTalent
   end
 
   def update_profile_type(user, applying)
-    if applying
-      user.update(profile_type: "applying")
-    else
-      user.update(profile_type: "talent")
-    end
+    user.update(profile_type: applying ? "applying" : "talent")
   end
 end

--- a/app/services/supporter/upgrade_to_talent.rb
+++ b/app/services/supporter/upgrade_to_talent.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Supporter::UpgradeToTalent
-  def call(user_id:)
+  def call(user_id:, applying: false)
     user = User.find(user_id)
 
     return false if user.talent.present?
@@ -9,6 +9,7 @@ class Supporter::UpgradeToTalent
     user.create_talent!
     user.talent.create_career_goal!
     user.talent.create_token!
+    update_profile_type(user, applying)
 
     create_invite(user)
 
@@ -37,5 +38,13 @@ class Supporter::UpgradeToTalent
     user.talent.profile_picture_data = user.investor.profile_picture_data
     user.talent.banner_data = user.investor.banner_data
     user.talent.save!
+  end
+
+  def update_profile_type(user, applying)
+    if applying
+      user.update(profile_type: "applying")
+    else
+      user.update(profile_type: "talent")
+    end
   end
 end

--- a/db/migrate/20220524112720_add_profile_type_to_users.rb
+++ b/db/migrate/20220524112720_add_profile_type_to_users.rb
@@ -1,5 +1,5 @@
 class AddProfileTypeToUsers < ActiveRecord::Migration[6.1]
   def change
-    add_column :users, :profile_type, :string, default: "supporter"
+    add_column :users, :profile_type, :string, default: "supporter", null: false
   end
 end

--- a/db/migrate/20220524112720_add_profile_type_to_users.rb
+++ b/db/migrate/20220524112720_add_profile_type_to_users.rb
@@ -1,0 +1,5 @@
+class AddProfileTypeToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :profile_type, :string, default: "supporter"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2022_05_24_112720) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -332,7 +333,7 @@ ActiveRecord::Schema.define(version: 2022_05_24_112720) do
     t.integer "member_nft_token_id"
     t.string "member_nft_tx"
     t.bigint "race_id"
-    t.string "profile_type", default: "supporter"
+    t.string "profile_type", default: "supporter", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invite_id"], name: "index_users_on_invite_id"
     t.index ["race_id"], name: "index_users_on_race_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_06_122951) do
-
+ActiveRecord::Schema.define(version: 2022_05_24_112720) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -333,6 +332,7 @@ ActiveRecord::Schema.define(version: 2022_05_06_122951) do
     t.integer "member_nft_token_id"
     t.string "member_nft_tx"
     t.bigint "race_id"
+    t.string "profile_type", default: "supporter"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invite_id"], name: "index_users_on_invite_id"
     t.index ["race_id"], name: "index_users_on_race_id"

--- a/lib/tasks/tmp/update_users_profile_type.rake
+++ b/lib/tasks/tmp/update_users_profile_type.rake
@@ -1,0 +1,11 @@
+namespace :users do
+  task update_profile_type: :environment do
+    puts "updating users"
+    User.find_each do |user|
+      if user.profile_type == "investor" && user.talent.present?
+        user.update(profile_type: "talent")
+      end
+    end
+    puts "users updated"
+  end
+end

--- a/lib/tasks/tmp/update_users_profile_type.rake
+++ b/lib/tasks/tmp/update_users_profile_type.rake
@@ -3,7 +3,7 @@ namespace :users do
     puts "updating users"
     User.find_each do |user|
       if user.profile_type == "investor" && user.talent.present?
-        user.update(profile_type: "talent")
+        user.update!(profile_type: "talent")
       end
     end
     puts "users updated"


### PR DESCRIPTION
## Summary
We decided to add a profile_type enum field to the user so we can take care of the flow from Supporter to Talent. This will need to have some intermediary steps like applying, waiting for approval and getting an approval

## Notion link

https://www.notion.so/talentprotocol/Upgrade-to-Talent-Account-02e0b226fffa4d52829bb16b4ace9926

## How to test?

Nothing should really change in this PR. Everything should work the same, it's just the foundation for the next PRs. We need to run the rake task before going forward with the next PRs so we always have the correct data live

## Notes

<!--- Notes you might consider worth adding. -->
