### PR TITLE
Add light background to discovey rows header

### DIFF
--- a/app/packs/stylesheets/_colors.scss
+++ b/app/packs/stylesheets/_colors.scss
@@ -77,6 +77,8 @@ $pink: #e1c3ff;
 $warning: #ffb200;
 
 // light mode colors
+$surface-01: #f5f6f7;
+$surface-01-hover: #ebedf0;
 $surface-hover: #eeeeef;
 $gray-surface-2: #ededef;
 

--- a/app/packs/stylesheets/custom/_talent.scss
+++ b/app/packs/stylesheets/custom/_talent.scss
@@ -24,12 +24,12 @@
   border: 8px solid $dark-bg-01;
 }
 
-.dark-body .talent-list-header {
+.talent-list-header {
   height: 277px;
   margin-top: -40px;
 
   &::before {
-    background-color: $gray-900;
+    background-color: $surface-01;
     content: "";
     height: inherit;
     z-index: -1;
@@ -37,8 +37,15 @@
     position: absolute;
     top: 0;
     width: 100vw;
-    border-bottom: 1px solid $gray-800;
+    border-bottom: 1px solid $surface-01-hover;
     margin-top: 66px;
+  }
+}
+
+.dark-body .talent-list-header {
+  &::before {
+    background-color: $gray-900;
+    border-bottom: 1px solid $gray-800;
   }
 }
 
@@ -188,20 +195,7 @@
     padding-right: 8px;
   }
 
-  .dark-body .talent-list-header {
+  .talent-list-header {
     height: 240px;
-
-    &::before {
-      background-color: $gray-900;
-      content: "";
-      height: inherit;
-      z-index: -1;
-      left: 0;
-      position: absolute;
-      top: 0;
-      width: 100vw;
-      border-bottom: 1px solid $gray-800;
-      margin-top: 66px;
-    }
   }
 }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -320,8 +320,8 @@ ActiveRecord::Schema.define(version: 2022_05_24_112720) do
     t.boolean "welcome_pop_up", default: false
     t.boolean "tokens_purchased", default: false
     t.boolean "token_purchase_reminder_sent", default: false
-    t.string "theme_preference", default: "light"
     t.boolean "disabled", default: false
+    t.string "theme_preference", default: "light"
     t.boolean "messaging_disabled", default: false
     t.jsonb "notification_preferences", default: {}
     t.string "user_nft_address"


### PR DESCRIPTION
## Summary

This PR adds the background on the discovery page headers in the light mode.

<img width="1672" alt="Captura de Tela 2022-05-27 às 12 53 37" src="https://user-images.githubusercontent.com/8901722/170694443-d7c97720-1173-4efc-95e7-65a32ecb6856.png">


## Notion link

https://talentprotocol.notion.site/Improve-Discover-Page-Automation-2645e05c601945d2b1cffa339d4c8d10

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
