### PR TITLE
Return 406 not acceptable when a json request is made on a html only endpoint

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,16 @@ class ApplicationController < ActionController::Base
     if Rails.env.development? || Rails.env.test?
       raise ActionController::RoutingError.new("We didn't find any routes that match your request.")
     else
-      redirect_to root_path
+      respond_to do |format|
+        format.html { redirect_to root_path }
+        format.json {
+          render(
+            json: {message: "We didn't find any routes that match your request."},
+            status: :not_found
+          )
+        }
+      end
+
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Rails.application.routes.draw do
   resources :discovery, only: [:show], param: :slug
 
   # Auth - Clearance generated routes
+
   resources :passwords, controller: "passwords", only: [:create, :new]
   resource :session, controller: "sessions", only: [:create]
 
@@ -97,11 +98,13 @@ Rails.application.routes.draw do
       only: [:edit, :update]
   end
 
-  get "/sign_up" => "pages#home", :as => :sign_up
-  get "/" => "sessions#new", :as => "sign_in"
-  delete "/" => "sessions#new", :as => "sign_in_redirect"
-  delete "/sign_out" => "sessions#destroy", :as => "sign_out"
-  get "/confirm_email(/:token)" => "email_confirmations#update", :as => "confirm_email"
+  constraints(format: :html) do
+    get "/sign_up" => "pages#home", :as => :sign_up
+    get "/" => "sessions#new", :as => "sign_in"
+    delete "/" => "sessions#new", :as => "sign_in_redirect"
+    delete "/sign_out" => "sessions#destroy", :as => "sign_out"
+    get "/confirm_email(/:token)" => "email_confirmations#update", :as => "confirm_email"
+  end
   # end Auth
 
   resources :wait_list, only: [:create, :index]
@@ -110,7 +113,9 @@ Rails.application.routes.draw do
   # redirect /talent to /u so we have the old route still working
   get "/talent/:username", to: redirect("/u/%{username}")
 
-  root to: "sessions#new", as: :root
+  constraints(format: :html) do
+    root to: "sessions#new", as: :root
+  end
 
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"


### PR DESCRIPTION
## Summary

This PR prevents json requests to html only endpoints to raise internal server errors. From now on it will return: 406 Not Acceptable

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
