### PR TITLE
Prevent json requests on html endpoints

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,16 @@ class ApplicationController < ActionController::Base
     if Rails.env.development? || Rails.env.test?
       raise ActionController::RoutingError.new("We didn't find any routes that match your request.")
     else
-      redirect_to root_path
+      respond_to do |format|
+        format.html { redirect_to root_path }
+        format.json {
+          render(
+            json: {message: "We didn't find any routes that match your request."},
+            status: :not_found
+          )
+        }
+      end
+
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,10 @@
 class SessionsController < Clearance::SessionsController
   protect_from_forgery
 
+  def new
+    respond_to :html
+  end
+
   def create
     email = params[:session][:email]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,9 +113,7 @@ Rails.application.routes.draw do
   # redirect /talent to /u so we have the old route still working
   get "/talent/:username", to: redirect("/u/%{username}")
 
-  constraints(format: :html) do
-    root to: "sessions#new", as: :root
-  end
+  root to: "sessions#new", as: :root
 
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Rails.application.routes.draw do
   resources :discovery, only: [:show], param: :slug
 
   # Auth - Clearance generated routes
+
   resources :passwords, controller: "passwords", only: [:create, :new]
   resource :session, controller: "sessions", only: [:create]
 
@@ -97,11 +98,13 @@ Rails.application.routes.draw do
       only: [:edit, :update]
   end
 
-  get "/sign_up" => "pages#home", :as => :sign_up
-  get "/" => "sessions#new", :as => "sign_in"
-  delete "/" => "sessions#new", :as => "sign_in_redirect"
-  delete "/sign_out" => "sessions#destroy", :as => "sign_out"
-  get "/confirm_email(/:token)" => "email_confirmations#update", :as => "confirm_email"
+  constraints(format: :html) do
+    get "/sign_up" => "pages#home", :as => :sign_up
+    get "/" => "sessions#new", :as => "sign_in"
+    delete "/" => "sessions#new", :as => "sign_in_redirect"
+    delete "/sign_out" => "sessions#destroy", :as => "sign_out"
+    get "/confirm_email(/:token)" => "email_confirmations#update", :as => "confirm_email"
+  end
   # end Auth
 
   resources :wait_list, only: [:create, :index]
@@ -110,7 +113,9 @@ Rails.application.routes.draw do
   # redirect /talent to /u so we have the old route still working
   get "/talent/:username", to: redirect("/u/%{username}")
 
-  root to: "sessions#new", as: :root
+  constraints(format: :html) do
+    root to: "sessions#new", as: :root
+  end
 
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"


### PR DESCRIPTION
## Summary

The root page is not accessible with the previous changes. This will make the route accessible and do the validation on the action.

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
