### PR TITLE
Prevent json requests on html endpoints

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,10 +1,6 @@
 class SessionsController < Clearance::SessionsController
   protect_from_forgery
 
-  # def new
-  #   respond_to :html
-  # end
-
   def create
     email = params[:session][:email]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,9 +102,10 @@ Rails.application.routes.draw do
     get "/sign_up" => "pages#home", :as => :sign_up
     get "/" => "sessions#new", :as => "sign_in"
     delete "/" => "sessions#new", :as => "sign_in_redirect"
-    delete "/sign_out" => "sessions#destroy", :as => "sign_out"
     get "/confirm_email(/:token)" => "email_confirmations#update", :as => "confirm_email"
   end
+
+  delete "/sign_out" => "sessions#destroy", :as => "sign_out"
   # end Auth
 
   resources :wait_list, only: [:create, :index]


### PR DESCRIPTION
## Summary

Allow sign out using json format request.

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
