### PR TITLE
Add admin process to allow users to launch their token

### DIFF
--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -13,7 +13,7 @@ class UserBlueprint < Blueprinter::Base
 
   view :extended do
     include_view :normal
-    fields :email, :wallet_id, :profile_type
+    fields :email, :wallet_id, :profile_type, :admin?
   end
 
   view :with_pictures do

--- a/app/controllers/api/v1/talent_controller.rb
+++ b/app/controllers/api/v1/talent_controller.rb
@@ -30,7 +30,7 @@ class API::V1::TalentController < ApplicationController
   end
 
   def update
-    if talent.id != current_user.talent.id
+    if !current_user.admin? && talent.id != current_user.talent&.id
       return render json: {error: "You don't have access to perform that action"}, status: :unauthorized
     end
 

--- a/app/controllers/talent_controller.rb
+++ b/app/controllers/talent_controller.rb
@@ -1,6 +1,6 @@
 class TalentController < ApplicationController
   def index
-    service = Talents::Search.new(filter_params: filter_params.to_h)
+    service = Talents::Search.new(filter_params: filter_params.to_h, admin: current_user.admin?)
     talents = service.call
     @talents = TalentBlueprint.render_as_json(talents.includes(:user, :token), view: :normal, current_user_watchlist: current_user_watchlist)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -105,6 +105,7 @@ class UsersController < ApplicationController
   end
 
   def should_see_talent_page?(talent)
-    (current_user.id == talent.user_id && talent.user.profile_type != "supporter") || talent.user.profile_type == "talent"
+    (current_user.id == talent.user_id && !talent.user.supporter?) ||
+      talent.user.talent? || current_user.admin?
   end
 end

--- a/app/packs/src/components/talent/TalentFilters.jsx
+++ b/app/packs/src/components/talent/TalentFilters.jsx
@@ -1,12 +1,23 @@
-import React, { useState } from "react";
-import { get } from "src/utils/requests";
+import React, { useMemo } from "react";
 
 import Dropdown from "react-bootstrap/Dropdown";
 import { P2, P3 } from "src/components/design_system/typography";
 import { OrderBy } from "src/components/icons";
 
-const TalentFilters = ({ status, setStatus, filter }) => {
-  const options = ["All", "Trending", "Latest added", "Launching soon"];
+const TalentFilters = ({ status, setStatus, filter, isAdmin = false }) => {
+  const options = useMemo(() => {
+    if (isAdmin) {
+      return [
+        "All",
+        "Trending",
+        "Latest added",
+        "Launching soon",
+        "Pending approval",
+      ];
+    }
+
+    return ["All", "Trending", "Latest added", "Launching soon"];
+  }, []);
 
   const selectedClass = (option) =>
     option == status ? " text-primary" : "text-black";

--- a/app/packs/src/components/talent/TalentOptions.jsx
+++ b/app/packs/src/components/talent/TalentOptions.jsx
@@ -21,6 +21,7 @@ const TalentOptions = ({
   setLocalTalents,
   setSelectedSort,
   setSortDirection,
+  isAdmin,
 }) => {
   const { mobile } = useWindowDimensionsHook();
   const url = new URL(document.location);
@@ -82,6 +83,7 @@ const TalentOptions = ({
             status={status}
             setStatus={setStatus}
             filter={filter}
+            isAdmin={isAdmin}
           />
         </div>
         <Button

--- a/app/packs/src/components/talent/TalentPage.jsx
+++ b/app/packs/src/components/talent/TalentPage.jsx
@@ -30,7 +30,7 @@ import {
 
 import cx from "classnames";
 
-const TalentPage = ({ talents }) => {
+const TalentPage = ({ talents, isAdmin }) => {
   const theme = useContext(ThemeContext);
   const { mobile } = useWindowDimensionsHook();
   const [localTalents, setLocalTalents] = useState(talents);
@@ -162,6 +162,7 @@ const TalentPage = ({ talents }) => {
         setLocalTalents={setLocalTalents}
         setSelectedSort={setSelectedSort}
         setSortDirection={setSortDirection}
+        isAdmin={isAdmin}
       />
       {localTalents.length === 0 && (
         <div className="d-flex justify-content-center mt-6">

--- a/app/services/talents/search.rb
+++ b/app/services/talents/search.rb
@@ -57,6 +57,8 @@ module Talents
           .active
           .where("tokens.deployed_at > ?", 1.month.ago)
           .order("tokens.deployed_at ASC")
+      elsif filter_params[:status] == "Pending approval"
+        Talent.joins(:user).where(user: {profile_type: "waiting_for_approval"})
       else
         talents
           .select("setseed(0.#{Date.today.jd}), talent.*")

--- a/app/views/talent/index.html.erb
+++ b/app/views/talent/index.html.erb
@@ -20,7 +20,8 @@
               isFollowing: talent['is_following'],
               userId: talent["user_id"]
             }
-          }
+          },
+          isAdmin: current_user.admin?
         },
         prerender: false) %>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -41,6 +41,7 @@
           currentUserId: current_user&.id,
           tokenLive: @talent["token"]["deployed"],
           isFollowing: @talent["is_following"],
+          admin: current_user.admin?,
           user: {
             id: @talent["user_id"],
             email: @talent["user"]["email"],


### PR DESCRIPTION
## Summary
We add a new option to the search dropdown on the /talents page, only for admins, so they can search by talents waiting for approval to launch their token.
Then, inside the user's profile, there's an "approve" button (when before there was a "buy button") so the user can be approved. after that the user can launch their own token

## Notion link

https://www.notion.so/talentprotocol/Upgrade-to-Talent-Account-02e0b226fffa4d52829bb16b4ace9926

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
