### PR TITLE
Tags style

### DIFF
--- a/app/packs/src/components/design_system/cards/Perk.jsx
+++ b/app/packs/src/components/design_system/cards/Perk.jsx
@@ -27,11 +27,11 @@ const Perk = ({
 
         <div className={`text-right ${mode}`}>
           {tokensLeftToRedeem === 0 ? (
-            <Tag className="tag-available" mode={mode}>
+            <Tag className="tag-available">
               <P3 bold text="Available" className="tag-available-label" />
             </Tag>
           ) : (
-            <Tag className="tag-unavailable" mode={mode}>
+            <Tag className="tag-unavailable">
               <P3 bold className="tag-unavailable-label">
                 Hold more {ethers.utils.commify(tokensLeftToRedeem)} {ticker}
               </P3>

--- a/app/packs/src/components/design_system/dropdowns/claim_rewards_dropdown/index.jsx
+++ b/app/packs/src/components/design_system/dropdowns/claim_rewards_dropdown/index.jsx
@@ -56,7 +56,7 @@ const ClaimRewardsDropdown = ({ className, mode, talentSymbol }) => {
             mode={mode}
             text="Claim Rewards to my wallet"
           />
-          <Tag className="text-primary-04 ml-2 tag-inside-dropdown" mode={mode}>
+          <Tag className="text-primary-04 ml-2 tag-inside-dropdown">
             <P3 className="text-primary-04" bold text="Coming Soon" />
           </Tag>
         </Dropdown.Item>

--- a/app/packs/src/components/design_system/tag/index.jsx
+++ b/app/packs/src/components/design_system/tag/index.jsx
@@ -4,13 +4,13 @@ import P2 from "src/components/design_system/typography/p2";
 import P3 from "src/components/design_system/typography/p3";
 import cx from "classnames";
 
-const Tag = ({ text, mode, size, children, className }) => {
+const Tag = ({ text, size, children, className }) => {
   return (
-    <div className={cx("tag-container", mode, className)}>
+    <div className={cx("tag-container", className)}>
       {text && (
         <>
-          {size === "normal" && <P2 mode={mode} text={text} />}
-          {size === "small" && <P3 mode={mode} text={text} />}
+          {size === "normal" && <P2 text={text} />}
+          {size === "small" && <P3 text={text} />}
         </>
       )}
       {children}
@@ -20,14 +20,12 @@ const Tag = ({ text, mode, size, children, className }) => {
 
 Tag.defaultProps = {
   text: null,
-  mode: "light",
   size: "normal",
   children: null,
 };
 
 Tag.propTypes = {
   text: string,
-  mode: oneOf(["light", "dark"]),
   size: string,
   children: node,
 };

--- a/app/packs/src/components/discovery/discovery_rows.jsx
+++ b/app/packs/src/components/discovery/discovery_rows.jsx
@@ -73,14 +73,14 @@ const DiscoveryRows = ({ discoveryRows, updateFollow }) => {
           className="cursor-pointer ml-2"
           target="_blank"
         >
-          <Tag className="cursor-pointer tag-container-secondary">
+          <Tag className="cursor-pointer secondary">
             <P3 className="current-color" bold text={row.badge} />
           </Tag>
         </a>
       );
     } else {
       return (
-        <Tag className="ml-2 tag-container-secondary">
+        <Tag className="ml-2 secondary">
           <P3 className="current-color" bold text={row.badge} />
         </Tag>
       );

--- a/app/packs/src/components/discovery/discovery_rows.jsx
+++ b/app/packs/src/components/discovery/discovery_rows.jsx
@@ -73,14 +73,14 @@ const DiscoveryRows = ({ discoveryRows, updateFollow }) => {
           className="cursor-pointer ml-2"
           target="_blank"
         >
-          <Tag className=" cursor-pointer">
+          <Tag className="cursor-pointer tag-container-secondary">
             <P3 className="current-color" bold text={row.badge} />
           </Tag>
         </a>
       );
     } else {
       return (
-        <Tag className="ml-2">
+        <Tag className="ml-2 tag-container-secondary">
           <P3 className="current-color" bold text={row.badge} />
         </Tag>
       );

--- a/app/packs/src/components/login/ChangePassword.jsx
+++ b/app/packs/src/components/login/ChangePassword.jsx
@@ -46,7 +46,7 @@ const ChangePasswordForm = ({
         />
         <div className="d-flex flex-wrap">
           {tags.map((tag) => (
-            <Tag mode={themePreference} className="mr-2  mt-2" key={tag}>
+            <Tag className="mr-2 mt-2" key={tag}>
               <P3 mode={themePreference} text={tag} bold />
             </Tag>
           ))}

--- a/app/packs/src/components/registration/RegisterPassword.jsx
+++ b/app/packs/src/components/registration/RegisterPassword.jsx
@@ -62,7 +62,6 @@ const RegisterPassword = ({ themePreference, changePassword, changeStep }) => {
           <div className="d-flex flex-wrap">
             {tags.map((tag) => (
               <Tag
-                mode={themePreference}
                 className={`mr-2 mt-2${errors[tag] ? "" : " bg-success"}`}
                 key={tag}
               >

--- a/app/packs/src/components/talent/UserTags.jsx
+++ b/app/packs/src/components/talent/UserTags.jsx
@@ -14,7 +14,7 @@ const UserTags = ({ tags, talent_id, className, mode }) => {
         }`}
       >
         {validTags.map((tag) => (
-          <Tag mode={mode} className="mr-2 mt-2" key={`${talent_id}_${tag}`}>
+          <Tag className="mr-2 mt-2" key={`${talent_id}_${tag}`}>
             <a href={`/talent?keyword=${tag}`} className="text-decoration-none">
               <P2 mode={mode} text={tag} bold role="button" />
             </a>

--- a/app/packs/stylesheets/application.scss
+++ b/app/packs/stylesheets/application.scss
@@ -2,6 +2,7 @@
 @import "bootstrap/overrides";
 @import "libs";
 @import "sizes";
+@import "colors";
 @import "custom/button";
 @import "custom/slider";
 @import "custom/tooltip";
@@ -29,7 +30,6 @@
 @import "custom/placeholder";
 @import "custom/portfolio";
 @import "custom/rewards";
-@import "colors";
 @import "types";
 
 ::-webkit-scrollbar {

--- a/app/packs/stylesheets/custom/_tags.scss
+++ b/app/packs/stylesheets/custom/_tags.scss
@@ -7,15 +7,23 @@
   width: fit-content;
   padding: 2px 8px;
   border-radius: 4px;
-  background-color: $primary-disabled;
+  background-color: $surface-hover;
 
   &.primary {
     background-color: $primary-200;
   }
+
+  &.secondary {
+    background-color: $primary-disabled;
+  }
 }
 
 .dark-body .tag-container {
-  background-color: $primary-shade-01;
+  background-color: $gray-800;
+
+  &.secondary {
+    background-color: $primary-shade-01;
+  }
 }
 
 .optional-tag-container {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10027,9 +10027,9 @@ memfs@^3.1.2, memfs@^3.2.2:
     fs-monkey "1.0.3"
 
 memfs@^3.4.3:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.4.3.tgz#fc08ac32363b6ea6c95381cabb4d67838180d4e1"
-  integrity sha512-eivjfi7Ahr6eQTn44nvTnR60e4a1Fs1Via2kCR5lHo/kyNoiMWaXCNJ/GpSd0ilXas2JSOl9B5FTIhflXu0hlg==
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.4.4.tgz#e8973cd8060548916adcca58a248e7805c715e89"
+  integrity sha512-W4gHNUE++1oSJVn8Y68jPXi+mkx3fXR5ITE/Ubz6EQ3xRpCN5k2CQ4AUR8094Z7211F876TyoBACGsIveqgiGA==
   dependencies:
     fs-monkey "1.0.3"
 
@@ -15063,9 +15063,9 @@ ws@^8.2.3:
   integrity sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==
 
 ws@^8.4.2:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.6.0.tgz#e5e9f1d9e7ff88083d0c0dd8281ea662a42c9c23"
-  integrity sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.7.0.tgz#eaf9d874b433aa00c0e0d8752532444875db3957"
+  integrity sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==
 
 xhr-request-promise@^0.1.2:
   version "0.1.3"


### PR DESCRIPTION
## Summary

This PR brings back the old style for tags in the talent page.
It keeps it only in the discovery page.

<img width="754" alt="Captura de Tela 2022-05-31 às 11 53 44" src="https://user-images.githubusercontent.com/8901722/171157643-efd2b9f1-0e3c-486c-8d53-837fda32ff88.png">

<img width="541" alt="Captura de Tela 2022-05-31 às 11 54 24" src="https://user-images.githubusercontent.com/8901722/171157776-fbdd6cda-2434-40c2-a3d0-5e85ef165fe9.png">

## Notion link

<!--- Link to the Notion task. -->

## How to test?

<!--- instructions on how to test the changes. -->

## Notes

<!--- Notes you might consider worth adding. -->
